### PR TITLE
example: improve wide-screen detection

### DIFF
--- a/example/src/commonMain/kotlin/UITest.kt
+++ b/example/src/commonMain/kotlin/UITest.kt
@@ -89,6 +89,8 @@ import utils.FPSMonitor
 
 private object UIConstants {
     val WIDE_SCREEN_THRESHOLD = 840.dp
+    val MEDIUM_WIDTH_THRESHOLD = 600.dp
+    const val PORTRAIT_ASPECT_RATIO_THRESHOLD = 1.2f
     const val MAIN_PAGE_INDEX = 0
     const val DROPDOWN_PAGE_INDEX = 1
     const val COLOR_PAGE_INDEX = 2
@@ -167,7 +169,13 @@ fun UITest(
         BoxWithConstraints(
             modifier = Modifier.fillMaxSize()
         ) {
-            val isWideScreen = maxWidth > UIConstants.WIDE_SCREEN_THRESHOLD
+            val isDefinitelyWide = maxWidth > UIConstants.WIDE_SCREEN_THRESHOLD
+
+            val isWideByShape = maxWidth > UIConstants.MEDIUM_WIDTH_THRESHOLD &&
+                    (maxHeight.value / maxWidth.value < UIConstants.PORTRAIT_ASPECT_RATIO_THRESHOLD)
+
+            val isWideScreen = isDefinitelyWide || isWideByShape
+
             uiState = uiState.copy(isWideScreen = isWideScreen)
 
             if (isWideScreen) {


### PR DESCRIPTION
The wide-screen detection logic is enhanced to better handle various device sizes and orientations.

The new logic considers two conditions:
- The screen width exceeds a large threshold (`WIDE_SCREEN_THRESHOLD`).
- The screen width is above a medium threshold (`MEDIUM_WIDTH_THRESHOLD`) and the aspect ratio is landscape-like.

This ensures a two-pane layout is used not only on very wide screens but also on devices like landscape phones or unfolded foldables.

Feel free to review and close this if you don't think it is necessary.