### PR TITLE
feat(SuperDialog): Hide keyboard when dialog is dismissed

### DIFF
--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperDialog.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperDialog.kt
@@ -98,20 +98,24 @@ fun SuperDialog(
     val currentOnDismissRequest by rememberUpdatedState(onDismissRequest)
     val density = LocalDensity.current
     val imeInsets = WindowInsets.ime
+    val imeBottom = imeInsets.getBottom(density)
+    val isLargeScreen = SuperDialogDefaults.isLargeScreen()
+    val exitTransition: ExitTransition? = remember(isLargeScreen, imeBottom) {
+        if (!isLargeScreen && imeBottom > 0) {
+            slideOutVertically(
+                targetOffsetY = { fullHeight -> fullHeight },
+                animationSpec = tween(350, easing = DecelerateEasing(0.8f))
+            )
+        } else {
+            null
+        }
+    }
 
     DialogLayout(
         visible = show,
         enableWindowDim = enableWindowDim,
         dimAlpha = dimAlpha,
-        exitTransition = if (imeInsets.getBottom(density) > 0) {
-            if (!SuperDialogDefaults.isLargeScreen()) {
-                SuperDialogDefaults.rememberDefaultDialogExitTransition()
-            } else {
-                null
-            }
-        } else {
-            null
-        }
+        exitTransition = exitTransition
     ) {
         SuperDialogContent(
             modifier = modifier,
@@ -283,16 +287,6 @@ object SuperDialogDefaults {
             derivedStateOf { (windowHeight >= 480.dp && windowWidth >= 840.dp) }
         }
         return largeScreen
-    }
-
-    @Composable
-    internal fun rememberDefaultDialogExitTransition(): ExitTransition {
-        return remember() {
-            slideOutVertically(
-                targetOffsetY = { fullHeight -> fullHeight },
-                animationSpec = tween(350, easing = DecelerateEasing(0.8f))
-            )
-        }
     }
 
     /**

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperDialog.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperDialog.kt
@@ -3,17 +3,21 @@
 
 package top.yukonga.miuix.kmp.extra
 
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.captionBarPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -45,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import com.mocharealm.gaze.capsule.ContinuousRoundedRectangle
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
+import top.yukonga.miuix.kmp.anim.DecelerateEasing
 import top.yukonga.miuix.kmp.basic.Text
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 import top.yukonga.miuix.kmp.utils.MiuixPopupUtils.Companion.DialogLayout
@@ -91,11 +96,22 @@ fun SuperDialog(
     val dialogHeightPx = remember { mutableIntStateOf(0) }
     val backProgress = remember { Animatable(0f) }
     val currentOnDismissRequest by rememberUpdatedState(onDismissRequest)
+    val density = LocalDensity.current
+    val imeInsets = WindowInsets.ime
 
     DialogLayout(
         visible = show,
         enableWindowDim = enableWindowDim,
-        dimAlpha = dimAlpha
+        dimAlpha = dimAlpha,
+        exitTransition = if (imeInsets.getBottom(density) > 0) {
+            if (!SuperDialogDefaults.isLargeScreen()) {
+                SuperDialogDefaults.rememberDefaultDialogExitTransition()
+            } else {
+                null
+            }
+        } else {
+            null
+        }
     ) {
         SuperDialogContent(
             modifier = modifier,
@@ -153,9 +169,7 @@ private fun SuperDialogContent(
     content: @Composable () -> Unit
 ) {
     val density = LocalDensity.current
-
     val roundedCorner by rememberUpdatedState(getRoundedCorner())
-
     val windowSize by rememberUpdatedState(getWindowSize())
     val windowWidth by remember(windowSize, density) {
         derivedStateOf { windowSize.width.dp / density.density }
@@ -163,23 +177,22 @@ private fun SuperDialogContent(
     val windowHeight by remember(windowSize, density) {
         derivedStateOf { windowSize.height.dp / density.density }
     }
-
     val bottomCornerRadius by remember(roundedCorner, outsideMargin.width) {
         derivedStateOf {
             if (roundedCorner != 0.dp) roundedCorner - outsideMargin.width else 32.dp
         }
     }
-
-    val contentAlignment by remember(windowHeight, windowWidth) {
+    val isLargeScreen by remember(windowWidth, windowHeight) {
+        derivedStateOf { windowHeight >= 480.dp && windowWidth >= 840.dp }
+    }
+    val contentAlignment by remember(isLargeScreen) {
         derivedStateOf {
-            if (windowHeight >= 480.dp && windowWidth >= 840.dp)
+            if (isLargeScreen)
                 Alignment.Center
             else
                 Alignment.BottomCenter
         }
     }
-
-    val isLargeScreen = windowHeight >= 480.dp && windowWidth >= 840.dp
 
     val rootBoxModifier = Modifier
         .then(
@@ -256,6 +269,31 @@ private fun SuperDialogContent(
 }
 
 object SuperDialogDefaults {
+    @Composable
+    internal fun isLargeScreen(): Boolean {
+        val density = LocalDensity.current
+        val windowSize = getWindowSize()
+        val windowWidth by remember(windowSize, density) {
+            derivedStateOf { windowSize.width.dp / density.density }
+        }
+        val windowHeight by remember(windowSize, density) {
+            derivedStateOf { windowSize.height.dp / density.density }
+        }
+        val largeScreen by remember(windowWidth, windowHeight) {
+            derivedStateOf { (windowHeight >= 480.dp && windowWidth >= 840.dp) }
+        }
+        return largeScreen
+    }
+
+    @Composable
+    internal fun rememberDefaultDialogExitTransition(): ExitTransition {
+        return remember() {
+            slideOutVertically(
+                targetOffsetY = { fullHeight -> fullHeight },
+                animationSpec = tween(350, easing = DecelerateEasing(0.8f))
+            )
+        }
+    }
 
     /**
      * The default color of the title.

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/utils/MiuixPopupUtils.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/utils/MiuixPopupUtils.kt
@@ -17,7 +17,9 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.ime
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -39,6 +41,7 @@ import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import top.yukonga.miuix.kmp.anim.DecelerateEasing
@@ -298,6 +301,10 @@ class MiuixPopupUtils {
             val visibleState = remember { MutableTransitionState(false) }
             var pendingOpen by remember { mutableStateOf(false) }
             var lastTarget by remember { mutableStateOf(false) }
+            val keyboardController = LocalSoftwareKeyboardController.current
+            val density = LocalDensity.current
+            val imeInsets = WindowInsets.ime
+
             LaunchedEffect(dialogState.showState.value) {
                 val newTarget = dialogState.showState.value
                 if (newTarget) {
@@ -307,6 +314,9 @@ class MiuixPopupUtils {
                         visibleState.targetState = true
                     }
                 } else {
+                    if (imeInsets.getBottom(density) > 0) {
+                        keyboardController?.hide()
+                    }
                     pendingOpen = false
                     visibleState.targetState = false
                 }


### PR DESCRIPTION
When a dialog is dismissed, automatically hide the software keyboard if it is visible. This prevents the keyboard from remaining on-screen after the dialog has closed.