### PR TITLE
refactor(Component): Fix hold down indication

### DIFF
--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Component.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Component.kt
@@ -132,8 +132,12 @@ fun BasicComponent(
     val currentOnClick by rememberUpdatedState(onClick)
 
     val holdDown = remember { mutableStateOf<HoldDownInteraction.HoldDown?>(null) }
-    LaunchedEffect(holdDownState) {
+    LaunchedEffect(holdDownState, interactionSource, indication) {
         if (holdDownState) {
+            holdDown.value?.let { oldValue ->
+                interactionSource.emit(HoldDownInteraction.Release(oldValue))
+                holdDown.value = null
+            }
             val interaction = HoldDownInteraction.HoldDown()
             holdDown.value = interaction
             interactionSource.emit(interaction)


### PR DESCRIPTION
When the `interactionSource` or `indication` changes, ensure that any existing `HoldDownInteraction` is properly released before a new one is emitted. This prevents the indication from getting stuck in the held-down state.