### PR TITLE
fix(PullToRefresh): Reset state to idle after rebound

### DIFF
--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/PullToRefresh.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/PullToRefresh.kt
@@ -356,6 +356,7 @@ class PullToRefreshState(
                     animateToSpring(0f)
                 } finally {
                     isRebounding = false
+                    internalRefreshState = RefreshState.Idle
                 }
             }
         }


### PR DESCRIPTION
When the rebound animation completes, ensure the `internalRefreshState` is reset to `Idle`. This prevents the refresh state from getting stuck after the pull-to-refresh action is finished or cancelled.