### PR TITLE
feat(dialog): Add onDismissFinished callback

### DIFF
--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperBottomSheet.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperBottomSheet.kt
@@ -83,7 +83,8 @@ import kotlin.coroutines.cancellation.CancellationException
  * @param enableWindowDim Whether to dim the window behind the [SuperBottomSheet].
  * @param cornerRadius The corner radius of the top corners of the [SuperBottomSheet].
  * @param sheetMaxWidth The maximum width of the [SuperBottomSheet].
- * @param onDismissRequest The callback when the [SuperBottomSheet] is dismissed.
+ * @param onDismissRequest Will called when the user tries to dismiss the Dialog by clicking outside or pressing the back button.
+ * @param onDismissFinished The callback when the [SuperDialog] is completely dismissed.
  * @param outsideMargin The margin outside the [SuperBottomSheet].
  * @param insideMargin The margin inside the [SuperBottomSheet].
  * @param defaultWindowInsetsPadding Whether to apply default window insets padding.
@@ -104,6 +105,7 @@ fun SuperBottomSheet(
     cornerRadius: Dp = SuperBottomSheetDefaults.cornerRadius,
     sheetMaxWidth: Dp = SuperBottomSheetDefaults.maxWidth,
     onDismissRequest: (() -> Unit)? = null,
+    onDismissFinished: (() -> Unit)? = null,
     outsideMargin: DpSize = SuperBottomSheetDefaults.outsideMargin,
     insideMargin: DpSize = SuperBottomSheetDefaults.insideMargin,
     defaultWindowInsetsPadding: Boolean = true,
@@ -152,7 +154,8 @@ fun SuperBottomSheet(
         exitTransition = rememberDefaultSheetExitTransition(),
         enableWindowDim = enableWindowDim,
         enableAutoLargeScreen = false,
-        dimAlpha = dimAlpha
+        dimAlpha = dimAlpha,
+        onDismissFinished = onDismissFinished
     ) {
         SuperBottomSheetContent(
             modifier = modifier,

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperDialog.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperDialog.kt
@@ -69,7 +69,8 @@ import top.yukonga.miuix.kmp.utils.getWindowSize
  * @param summary The summary of the [SuperDialog].
  * @param summaryColor The color of the summary.
  * @param backgroundColor The background color of the [SuperDialog].
- * @param onDismissRequest The callback when the [SuperDialog] is dismissed.
+ * @param onDismissRequest Will called when the user tries to dismiss the Dialog by clicking outside or pressing the back button.
+ * @param onDismissFinished The callback when the [SuperDialog] is completely dismissed.
  * @param outsideMargin The margin outside the [SuperDialog].
  * @param insideMargin The margin inside the [SuperDialog].
  * @param defaultWindowInsetsPadding Whether to apply default window insets padding to the [SuperDialog].
@@ -87,6 +88,7 @@ fun SuperDialog(
     backgroundColor: Color = SuperDialogDefaults.backgroundColor(),
     enableWindowDim: Boolean = true,
     onDismissRequest: (() -> Unit)? = null,
+    onDismissFinished: (() -> Unit)? = null,
     outsideMargin: DpSize = SuperDialogDefaults.outsideMargin,
     insideMargin: DpSize = SuperDialogDefaults.insideMargin,
     defaultWindowInsetsPadding: Boolean = true,
@@ -118,7 +120,8 @@ fun SuperDialog(
         visible = show,
         enableWindowDim = enableWindowDim,
         dimAlpha = dimAlpha,
-        exitTransition = exitTransition
+        exitTransition = exitTransition,
+        onDismissFinished = onDismissFinished
     ) {
         SuperDialogContent(
             modifier = modifier,

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/WindowBottomSheet.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/WindowBottomSheet.kt
@@ -66,7 +66,8 @@ import top.yukonga.miuix.kmp.utils.removePlatformDialogDefaultEffects
  * @param enableWindowDim Whether to dim the window behind the [WindowBottomSheet].
  * @param cornerRadius The corner radius of the top corners of the [WindowBottomSheet].
  * @param sheetMaxWidth The maximum width of the [WindowBottomSheet].
- * @param onDismissRequest The callback when the [WindowBottomSheet] is dismissed.
+ * @param onDismissRequest Will called when the user tries to dismiss the Dialog by clicking outside or pressing the back button.
+ * @param onDismissFinished The callback when the [SuperDialog] is completely dismissed.
  * @param outsideMargin The margin outside the [WindowBottomSheet].
  * @param insideMargin The margin inside the [WindowBottomSheet].
  * @param defaultWindowInsetsPadding Whether to apply default window insets padding.
@@ -87,6 +88,7 @@ fun WindowBottomSheet(
     cornerRadius: Dp = WindowBottomSheetDefaults.cornerRadius,
     sheetMaxWidth: Dp = WindowBottomSheetDefaults.maxWidth,
     onDismissRequest: (() -> Unit)? = null,
+    onDismissFinished: (() -> Unit)? = null,
     outsideMargin: DpSize = WindowBottomSheetDefaults.outsideMargin,
     insideMargin: DpSize = WindowBottomSheetDefaults.insideMargin,
     defaultWindowInsetsPadding: Boolean = true,
@@ -104,9 +106,16 @@ fun WindowBottomSheet(
     val dimAlpha = remember { mutableFloatStateOf(1f) }
     val dragSnapChannel = remember { Channel<Float>(capacity = Channel.CONFLATED) }
     val currentOnDismissRequest by rememberUpdatedState(onDismissRequest)
+    val currentOnDismissFinished by rememberUpdatedState(onDismissFinished)
 
     val dismissPending = remember { mutableStateOf(false) }
     val outsideDismissDeferred = remember { mutableStateOf(false) }
+
+    LaunchedEffect(internalVisible.currentState, show.value) {
+        if (!internalVisible.currentState && !show.value) {
+            currentOnDismissFinished?.invoke()
+        }
+    }
 
     LaunchedEffect(show.value) {
         internalVisible.targetState = show.value

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/WindowDialog.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/WindowDialog.kt
@@ -67,7 +67,8 @@ import top.yukonga.miuix.kmp.utils.removePlatformDialogDefaultEffects
  * @param summary The summary of the [WindowDialog].
  * @param summaryColor The color of the summary.
  * @param backgroundColor The background color of the [WindowDialog].
- * @param onDismissRequest The callback when the [WindowDialog] is dismissed.
+ * @param onDismissRequest Will called when the user tries to dismiss the Dialog by clicking outside or pressing the back button.
+ * @param onDismissFinished The callback when the [SuperDialog] is completely dismissed.
  * @param outsideMargin The margin outside the [WindowDialog].
  * @param insideMargin The margin inside the [WindowDialog].
  * @param defaultWindowInsetsPadding Whether to apply default window insets padding to the [WindowDialog].
@@ -84,6 +85,7 @@ fun WindowDialog(
     summaryColor: Color = WindowDialogDefaults.summaryColor(),
     backgroundColor: Color = WindowDialogDefaults.backgroundColor(),
     onDismissRequest: (() -> Unit)? = null,
+    onDismissFinished: (() -> Unit)? = null,
     outsideMargin: DpSize = WindowDialogDefaults.outsideMargin,
     insideMargin: DpSize = WindowDialogDefaults.insideMargin,
     defaultWindowInsetsPadding: Boolean = true,
@@ -118,6 +120,13 @@ fun WindowDialog(
     val dismissPending = remember { mutableStateOf(false) }
     val outsideDismissDeferred = remember { mutableStateOf(false) }
     val currentOnDismissInternal by rememberUpdatedState(onDismissRequest)
+    val currentOnDismissFinished by rememberUpdatedState(onDismissFinished)
+
+    LaunchedEffect(internalVisible.currentState, show.value) {
+        if (!internalVisible.currentState && !show.value){
+            currentOnDismissFinished?.invoke()
+        }
+    }
 
     LaunchedEffect(show.value) {
         internalVisible.targetState = show.value

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/utils/MiuixPopupUtils.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/utils/MiuixPopupUtils.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import top.yukonga.miuix.kmp.anim.DecelerateEasing
 import top.yukonga.miuix.kmp.basic.Scaffold
+import top.yukonga.miuix.kmp.extra.SuperDialog
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 
 /**
@@ -77,6 +78,7 @@ class MiuixPopupUtils {
         var dimEnterTransition by mutableStateOf<EnterTransition?>(null)
         var dimExitTransition by mutableStateOf<ExitTransition?>(null)
         var dimAlpha by mutableStateOf<MutableState<Float>?>(null)
+        var onDismissFinished by mutableStateOf<(() -> Unit)?>(null)
         var content by mutableStateOf<@Composable () -> Unit>({})
     }
 
@@ -157,6 +159,7 @@ class MiuixPopupUtils {
          * @param dimExitTransition Optional, custom exit animation for dim layer.
          * @param dimAlpha Optional, a mutable state to dynamically control the dim layer alpha (0f-1f).
          *   When provided, the dim layer will use this alpha value instead of default animations.
+         * @param onDismissFinished The callback when the [SuperDialog] is completely dismissed.
          * @param content The [Composable] content of the dialog.
          */
         @Composable
@@ -169,6 +172,7 @@ class MiuixPopupUtils {
             dimEnterTransition: EnterTransition? = null,
             dimExitTransition: ExitTransition? = null,
             dimAlpha: MutableState<Float>? = null,
+            onDismissFinished: (() -> Unit)? = null,
             content: (@Composable () -> Unit)? = null,
         ) {
             if (content == null) {
@@ -189,6 +193,7 @@ class MiuixPopupUtils {
             val latestDimEnter by rememberUpdatedState(dimEnterTransition)
             val latestDimExit by rememberUpdatedState(dimExitTransition)
             val latestDimAlpha by rememberUpdatedState(dimAlpha)
+            val latestOnDismissFinished by rememberUpdatedState(onDismissFinished)
             val latestContent by rememberUpdatedState(content)
 
             SideEffect {
@@ -199,6 +204,7 @@ class MiuixPopupUtils {
                 state.dimEnterTransition = latestDimEnter
                 state.dimExitTransition = latestDimExit
                 state.dimAlpha = latestDimAlpha
+                state.onDismissFinished = latestOnDismissFinished
                 state.content = latestContent
             }
 
@@ -383,6 +389,7 @@ class MiuixPopupUtils {
                 DisposableEffect(dialogState.showState) {
                     onDispose {
                         if (!dialogState.showState.value) {
+                            dialogState.onDismissFinished?.invoke()
                             dialogStates.removeAll { it.showState === dialogState.showState }
                         }
                     }


### PR DESCRIPTION
Introduces an `onDismissFinished` callback to `SuperDialog`, `WindowDialog`, `SuperBottomSheet`, and `WindowBottomSheet`.

This new callback is invoked when the dialog's dismiss animation has fully completed, allowing for actions to be triggered after the dialog is no longer visible.