### PR TITLE
library: Refactor ColorPicker to be controlled component

### DIFF
--- a/docs/components/colorpalette.md
+++ b/docs/components/colorpalette.md
@@ -1,6 +1,8 @@
 # ColorPalette
 
-`ColorPalette` is a HSV color grid component with a built‑in alpha slider and an optional gray column. It uses a single Canvas and minimizes recomposition during drag interactions.  With real-time color preview.
+`ColorPalette` is a HSV color grid component with a built‑in alpha slider and an optional gray
+column. It uses a single Canvas and minimizes recomposition during drag interactions. With real-time
+color preview.
 
 <div style="position: relative; max-width: 700px; height: 300px; border-radius: 10px; overflow: hidden; border: 1px solid #777;">
     <iframe id="demoIframe" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;" src="../compose/index.html?id=colorPalette" title="Demo" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin"></iframe>
@@ -18,7 +20,7 @@ import top.yukonga.miuix.kmp.basic.ColorPalette
 var selectedColor by remember { mutableStateOf(Color.Red) }
 
 ColorPalette(
-    initialColor = selectedColor,
+    color = selectedColor,
     onColorChanged = { newColor ->
         selectedColor = newColor
     }
@@ -33,7 +35,7 @@ Hide the preview panel at the top by setting `showPreview` to `false`:
 
 ```kotlin
 ColorPalette(
-    initialColor = selected,
+    color = selected,
     onColorChanged = { newColor ->
         selectedColor = newColor
     },
@@ -47,7 +49,7 @@ You can change the number of rows and hue columns, and toggle the gray column at
 
 ```kotlin
 ColorPalette(
-    initialColor = selected,
+    color = selected,
     onColorChanged = { newColor ->
         selectedColor = newColor
     },
@@ -63,7 +65,7 @@ Control the palette corner radius and the selection indicator radius:
 
 ```kotlin
 ColorPalette(
-    initialColor = selected,
+    color = selected,
     onColorChanged = { newColor ->
         selectedColor = newColor
     },
@@ -76,31 +78,32 @@ ColorPalette(
 
 ## Properties
 
-| Property          | Type            | Description                                                        | Default   | Required |
-| ----------------- | --------------- | ------------------------------------------------------------------ | --------- | -------- |
-| initialColor      | Color           | Initial color                                                      | -         | Yes      |
-| onColorChanged    | (Color) -> Unit | Callback when selection changes                                    | -         | Yes      |
-| modifier          | Modifier        | Modifier for the component                                         | Modifier  | No       |
-| rows              | Int             | Grid rows (top: brighter/lower saturation → bottom: darker/higher) | 7         | No       |
-| hueColumns        | Int             | Number of hue columns                                              | 12        | No       |
-| includeGrayColumn | Boolean         | Whether to show the gray column at the right                       | true      | No       |
-| showPreview       | Boolean         | Whether to show the color preview panel                            | true      | No       |
-| cornerRadius      | Dp              | Palette corner radius                                              | 16.dp     | No       |
-| indicatorRadius   | Dp              | Selection indicator radius                                         | 10.dp     | No       |
+| Property          | Type            | Description                                                        | Default  | Required |
+|-------------------|-----------------|--------------------------------------------------------------------|----------|----------|
+| color             | Color           | Current color                                                      | -        | Yes      |
+| onColorChanged    | (Color) -> Unit | Callback when selection changes                                    | -        | Yes      |
+| modifier          | Modifier        | Modifier for the component                                         | Modifier | No       |
+| rows              | Int             | Grid rows (top: brighter/lower saturation → bottom: darker/higher) | 7        | No       |
+| hueColumns        | Int             | Number of hue columns                                              | 12       | No       |
+| includeGrayColumn | Boolean         | Whether to show the gray column at the right                       | true     | No       |
+| showPreview       | Boolean         | Whether to show the color preview panel                            | true     | No       |
+| cornerRadius      | Dp              | Palette corner radius                                              | 16.dp    | No       |
+| indicatorRadius   | Dp              | Selection indicator radius                                         | 10.dp    | No       |
 
 ## Advanced Usage
 
 ### Using in Forms
 
-Combine with other inputs to build a simple color form. The example below maintains a HEX string. You may extend it to include alpha if needed.
+Combine with other inputs to build a simple color form. The example below maintains a HEX string.
+You may extend it to include alpha if needed.
 
 ```kotlin
 var currentColor by remember { mutableStateOf(Color(0xFF2196F3)) }
 var hexValue by remember(currentColor) {
     mutableStateOf(
         "#${(currentColor.red * 255).toInt().toString(16).padStart(2, '0').uppercase()}" +
-            (currentColor.green * 255).toInt().toString(16).padStart(2, '0').uppercase() +
-            (currentColor.blue * 255).toInt().toString(16).padStart(2, '0').uppercase()
+                (currentColor.green * 255).toInt().toString(16).padStart(2, '0').uppercase() +
+                (currentColor.blue * 255).toInt().toString(16).padStart(2, '0').uppercase()
     )
 }
 
@@ -116,7 +119,7 @@ Surface {
         )
         Spacer(modifier = Modifier.height(16.dp))
         ColorPalette(
-            initialColor = currentColor,
+            color = currentColor,
             onColorChanged = {
                 currentColor = it
                 hexValue = "#${(it.red * 255).toInt().toString(16).padStart(2, '0').uppercase()}" +
@@ -155,7 +158,7 @@ Scaffold {
     ) {
         Column {
             ColorPalette(
-                initialColor = selectedColor,
+                color = selectedColor,
                 onColorChanged = { selectedColor = it }
             )
             Spacer(modifier = Modifier.height(16.dp))

--- a/docs/components/colorpicker.md
+++ b/docs/components/colorpicker.md
@@ -1,6 +1,8 @@
 # ColorPicker
 
-`ColorPicker` is a color selection component in Miuix that allows users to pick colors by adjusting hue, saturation, brightness, and transparency. The component provides an intuitive slider interface with haptic feedback and real-time color preview.
+`ColorPicker` is a color selection component in Miuix that allows users to pick colors by adjusting
+hue, saturation, brightness, and transparency. The component provides an intuitive slider interface
+with haptic feedback and real-time color preview.
 
 <div style="position: relative; max-width: 700px; height: 260px; border-radius: 10px; overflow: hidden; border: 1px solid #777;">
     <iframe id="demoIframe" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;" src="../compose/index.html?id=colorPicker" title="Demo" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin"></iframe>
@@ -20,7 +22,7 @@ The ColorPicker component enables users to select custom colors:
 var selectedColor by remember { mutableStateOf(Color.Red) }
 
 ColorPicker(
-    initialColor = selectedColor,
+    color = selectedColor,
     onColorChanged = { newColor ->
         selectedColor = newColor
     }
@@ -31,11 +33,12 @@ ColorPicker(
 
 ### Without Color Preview
 
-By default, ColorPicker displays a preview of the currently selected color. If you don't want to show the default color preview, set `showPreview` to `false`:
+By default, ColorPicker displays a preview of the currently selected color. If you don't want to
+show the default color preview, set `showPreview` to `false`:
 
 ```kotlin
 ColorPicker(
-    initialColor = Color.Blue,
+    color = Color.Blue,
     onColorChanged = { /* Handle color change */ },
     showPreview = false
 )
@@ -43,11 +46,12 @@ ColorPicker(
 
 ## Haptic Feedback
 
-ColorPicker supports haptic feedback, which can be customized using the `hapticEffect` parameter. See [SliderHapticEffect](../components/slider#sliderhapticeffect) for details.
+ColorPicker supports haptic feedback, which can be customized using the `hapticEffect` parameter.
+See [SliderHapticEffect](../components/slider#sliderhapticeffect) for details.
 
 ```kotlin
 ColorPicker(
-    initialColor = Color.Green,
+    color = Color.Green,
     onColorChanged = { /* Handle color change */ },
     hapticEffect = SliderHapticEffect.Step
 )
@@ -58,8 +62,8 @@ ColorPicker(
 ### ColorPicker Properties
 
 | Property Name  | Type                              | Description                   | Default Value                      | Required |
-| -------------- | --------------------------------- | ----------------------------- | ---------------------------------- | -------- |
-| initialColor   | Color                             | Initial color                 | -                                  | Yes      |
+|----------------|-----------------------------------|-------------------------------|------------------------------------|----------|
+| color          | Color                             | Current color                 | -                                  | Yes      |
 | onColorChanged | (Color) -> Unit                   | Callback for color changes    | -                                  | Yes      |
 | modifier       | Modifier                          | Modifier for the component    | Modifier                           | No       |
 | showPreview    | Boolean                           | Show color preview            | true                               | No       |
@@ -137,13 +141,14 @@ ColorPicker supports multiple color spaces via `colorSpace`:
 - `ColorSpace.HSV` — classic HSV sliders (Hue, Saturation, Value, Alpha).
 - `ColorSpace.OKHSV` — perceptual HSV variant based on OkLCH, more uniform hue steps.
 - `ColorSpace.OKLAB` — OkLab sliders (Lightness, a, b, Alpha) for perceptual editing.
-- `ColorSpace.OKLCH` — OkLCH sliders (Lightness, Chroma, Hue, Alpha). Chroma is clamped to typical sRGB gamut.
+- `ColorSpace.OKLCH` — OkLCH sliders (Lightness, Chroma, Hue, Alpha). Chroma is clamped to typical
+  sRGB gamut.
 
 Example: use the OKLCH color space
 
 ```kotlin
 ColorPicker(
-    initialColor = Color(0xFF4CAF50),
+    color = Color(0xFF4CAF50),
     onColorChanged = { /* Handle color change */ },
     colorSpace = ColorSpace.OKLCH
 )
@@ -157,7 +162,7 @@ Combine with other input controls to create a color selection form:
 var currentColor by remember { mutableStateOf(Color.Red) }
 var hexValue by remember(currentColor) {
     mutableStateOf(
-            "#${(currentColor.red * 255).toInt().toString(16).padStart(2, '0').uppercase()}" +
+        "#${(currentColor.red * 255).toInt().toString(16).padStart(2, '0').uppercase()}" +
                 (currentColor.green * 255).toInt().toString(16).padStart(2, '0').uppercase() +
                 (currentColor.blue * 255).toInt().toString(16).padStart(2, '0').uppercase()
     )
@@ -175,7 +180,7 @@ Surface {
         )
         Spacer(modifier = Modifier.height(16.dp))
         ColorPicker(
-            initialColor = currentColor,
+            color = currentColor,
             onColorChanged = {
                 currentColor = it
                 hexValue = "#${(it.red * 255).toInt().toString(16).padStart(2, '0').uppercase()}" +
@@ -214,7 +219,7 @@ Scaffold {
     ) {
         Column {
             ColorPicker(
-                initialColor = selectedColor,
+                color = selectedColor,
                 onColorChanged = { selectedColor = it }
             )
             Spacer(modifier = Modifier.height(16.dp))

--- a/docs/demo/src/commonMain/kotlin/ColorPaletteDemo.kt
+++ b/docs/demo/src/commonMain/kotlin/ColorPaletteDemo.kt
@@ -41,7 +41,7 @@ fun ColorPaletteDemo() {
             val miuixColor = MiuixTheme.colorScheme.primary
             var selectedColor by remember { mutableStateOf(miuixColor) }
             ColorPalette(
-                initialColor = selectedColor,
+                color = selectedColor,
                 onColorChanged = { selectedColor = it },
             )
         }

--- a/docs/demo/src/commonMain/kotlin/ColorPickerDemo.kt
+++ b/docs/demo/src/commonMain/kotlin/ColorPickerDemo.kt
@@ -42,7 +42,7 @@ fun ColorPickerDemo() {
             val miuixColor = MiuixTheme.colorScheme.primary
             var selectedColor by remember { mutableStateOf(miuixColor) }
             ColorPicker(
-                initialColor = selectedColor,
+                color = selectedColor,
                 onColorChanged = { selectedColor = it },
                 hapticEffect = SliderDefaults.SliderHapticEffect.Step,
             )

--- a/docs/zh_CN/components/colorpalette.md
+++ b/docs/zh_CN/components/colorpalette.md
@@ -1,6 +1,7 @@
 # ColorPalette 调色盘
 
-ColorPalette 是一个 HSV 带有透明度滑条的网格调色盘组件，可选在右侧显示灰度列。实现采用单 Canvas 渲染、拖拽过程最小重组，支持实时颜色预览。
+ColorPalette 是一个 HSV 带有透明度滑条的网格调色盘组件，可选在右侧显示灰度列。实现采用单 Canvas
+渲染、拖拽过程最小重组，支持实时颜色预览。
 
 <div style="position: relative; max-width: 700px; height: 300px; border-radius: 10px; overflow: hidden; border: 1px solid #777;">
     <iframe id="demoIframe" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;" src="../../compose/index.html?id=colorPalette" title="Demo" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin"></iframe>
@@ -18,7 +19,7 @@ import top.yukonga.miuix.kmp.basic.ColorPalette
 var selectedColor by remember { mutableStateOf(Color.Red) }
 
 ColorPalette(
-    initialColor = selectedColor,
+    color = selectedColor,
     onColorChanged = { newColor ->
         selectedColor = newColor
     }
@@ -33,7 +34,7 @@ ColorPalette(
 
 ```kotlin
 ColorPalette(
-    initialColor = selectedColor,
+    color = selectedColor,
     onColorChanged = { newColor ->
         selectedColor = newColor
     },
@@ -47,7 +48,7 @@ ColorPalette(
 
 ```kotlin
 ColorPalette(
-    initialColor = selectedColor,
+    color = selectedColor,
     onColorChanged = { newColor ->
         selectedColor = newColor
     },
@@ -63,7 +64,7 @@ ColorPalette(
 
 ```kotlin
 ColorPalette(
-    initialColor = selectedColor,
+    color = selectedColor,
     onColorChanged = { newColor ->
         selectedColor = newColor
     },
@@ -76,17 +77,17 @@ ColorPalette(
 
 ## 属性
 
-| 属性              | 类型            | 说明                                        | 默认   | 必填 |
-| ----------------- | --------------- | ------------------------------------------- | ------ | ---- |
-| initialColor      | Color           | 初始颜色                                    | -      | 是   |
-| onColorChanged    | (Color) -> Unit | 颜色变化回调                                | -      | 是   |
-| modifier          | Modifier        | 组件修饰符                                  | Modifier | 否 |
-| rows              | Int             | 网格行数（上亮低饱和 → 下暗高饱和）         | 7      | 否   |
-| hueColumns        | Int             | 色相列数                                    | 12     | 否   |
-| includeGrayColumn | Boolean         | 是否显示右侧灰度列                          | true   | 否   |
-| showPreview       | Boolean         | 是否显示顶部颜色预览面板                    | true   | 否   |
-| cornerRadius      | Dp              | 容器圆角                                    | 16.dp  | 否   |
-| indicatorRadius   | Dp              | 选中指示器半径                              | 10.dp  | 否   |
+| 属性                | 类型              | 说明                  | 默认       | 必填 |
+|-------------------|-----------------|---------------------|----------|----|
+| color             | Color           | 当前颜色                | -        | 是  |
+| onColorChanged    | (Color) -> Unit | 颜色变化回调              | -        | 是  |
+| modifier          | Modifier        | 组件修饰符               | Modifier | 否  |
+| rows              | Int             | 网格行数（上亮低饱和 → 下暗高饱和） | 7        | 否  |
+| hueColumns        | Int             | 色相列数                | 12       | 否  |
+| includeGrayColumn | Boolean         | 是否显示右侧灰度列           | true     | 否  |
+| showPreview       | Boolean         | 是否显示顶部颜色预览面板        | true     | 否  |
+| cornerRadius      | Dp              | 容器圆角                | 16.dp    | 否  |
+| indicatorRadius   | Dp              | 选中指示器半径             | 10.dp    | 否  |
 
 ## 进阶用法
 
@@ -99,8 +100,8 @@ var currentColor by remember { mutableStateOf(Color(0xFF2196F3)) }
 var hexValue by remember(currentColor) {
     mutableStateOf(
         "#${(currentColor.red * 255).toInt().toString(16).padStart(2, '0').uppercase()}" +
-            (currentColor.green * 255).toInt().toString(16).padStart(2, '0').uppercase() +
-            (currentColor.blue * 255).toInt().toString(16).padStart(2, '0').uppercase()
+                (currentColor.green * 255).toInt().toString(16).padStart(2, '0').uppercase() +
+                (currentColor.blue * 255).toInt().toString(16).padStart(2, '0').uppercase()
     )
 }
 
@@ -116,7 +117,7 @@ Surface {
         )
         Spacer(modifier = Modifier.height(16.dp))
         ColorPalette(
-            initialColor = currentColor,
+            color = currentColor,
             onColorChanged = {
                 currentColor = it
                 hexValue = "#${(it.red * 255).toInt().toString(16).padStart(2, '0').uppercase()}" +
@@ -155,7 +156,7 @@ Scaffold {
     ) {
         Column {
             ColorPalette(
-                initialColor = selectedColor,
+                color = selectedColor,
                 onColorChanged = { selectedColor = it }
             )
             Spacer(modifier = Modifier.height(16.dp))

--- a/docs/zh_CN/components/colorpicker.md
+++ b/docs/zh_CN/components/colorpicker.md
@@ -20,7 +20,7 @@ ColorPicker 组件可以让用户选择自定义颜色：
 var selectedColor by remember { mutableStateOf(Color.Red) }
 
 ColorPicker(
-    initialColor = selectedColor,
+    color = selectedColor,
     onColorChanged = { newColor ->
         selectedColor = newColor
     }
@@ -31,11 +31,12 @@ ColorPicker(
 
 ### 不带颜色预览
 
-默认情况下，ColorPicker 会显示当前选择的颜色预览，如果不想显示默认的颜色预览，可以将 `showPreview` 设置为 `false`：
+默认情况下，ColorPicker 会显示当前选择的颜色预览，如果不想显示默认的颜色预览，可以将 `showPreview` 设置为
+`false`：
 
 ```kotlin
 ColorPicker(
-    initialColor = Color.Blue,
+    color = Color.Blue,
     onColorChanged = { /* 处理颜色变化 */ },
     showPreview = false
 )
@@ -43,11 +44,12 @@ ColorPicker(
 
 ## 触觉反馈
 
-ColorPicker 支持触觉反馈，可以通过 `hapticEffect` 参数自定义反馈效果，详见 [SliderHapticEffect](../components/slider#sliderhapticeffect)。
+ColorPicker 支持触觉反馈，可以通过 `hapticEffect`
+参数自定义反馈效果，详见 [SliderHapticEffect](../components/slider#sliderhapticeffect)。
 
 ```kotlin
 ColorPicker(
-    initialColor = Color.Green,
+    color = Color.Green,
     onColorChanged = { /* 处理颜色变化 */ },
     hapticEffect = SliderHapticEffect.Step
 )
@@ -57,14 +59,14 @@ ColorPicker(
 
 ### ColorPicker 属性
 
-| 属性名         | 类型                              | 说明                 | 默认值                             | 是否必须 |
-| -------------- | --------------------------------- | -------------------- | ---------------------------------- | -------- |
-| initialColor   | Color                             | 初始颜色             | -                                  | 是       |
-| onColorChanged | (Color) -> Unit                   | 颜色变化时的回调函数 | -                                  | 是       |
-| modifier       | Modifier                          | 应用于组件的修饰符   | Modifier                           | 否       |
-| showPreview    | Boolean                           | 是否显示颜色预览     | true                               | 否       |
-| hapticEffect   | SliderDefaults.SliderHapticEffect | 滑块的触觉反馈效果   | SliderDefaults.DefaultHapticEffect | 否       |
-| colorSpace     | ColorSpace                        | 选择使用的颜色空间   | ColorSpace.HSV                     | 否       |
+| 属性名            | 类型                                | 说明         | 默认值                                | 是否必须 |
+|----------------|-----------------------------------|------------|------------------------------------|------|
+| color          | Color                             | 当前颜色       | -                                  | 是    |
+| onColorChanged | (Color) -> Unit                   | 颜色变化时的回调函数 | -                                  | 是    |
+| modifier       | Modifier                          | 应用于组件的修饰符  | Modifier                           | 否    |
+| showPreview    | Boolean                           | 是否显示颜色预览   | true                               | 否    |
+| hapticEffect   | SliderDefaults.SliderHapticEffect | 滑块的触觉反馈效果  | SliderDefaults.DefaultHapticEffect | 否    |
+| colorSpace     | ColorSpace                        | 选择使用的颜色空间  | ColorSpace.HSV                     | 否    |
 
 ## 单独使用滑块组件
 
@@ -77,8 +79,8 @@ var hue by remember { mutableStateOf(0f) }
 
 HueSlider(
     currentHue = hue,
-    onHueChanged = { newHue -> 
-        hue = newHue * 360f 
+    onHueChanged = { newHue ->
+        hue = newHue * 360f
     }
 )
 ```
@@ -133,6 +135,7 @@ AlphaSlider(
 ### 颜色空间
 
 ColorPicker 通过 `colorSpace` 支持多种颜色空间：
+
 - `ColorSpace.HSV` — 经典 HSV 滑条（色相、饱和度、明度、透明度）。
 - `ColorSpace.OKHSV` — 基于 OkLCH 的感知 HSV 变体，色相步进更均匀。
 - `ColorSpace.OKLAB` — OkLab 滑条（亮度 L、a、b、透明度），更符合人眼的感知。
@@ -142,7 +145,7 @@ ColorPicker 通过 `colorSpace` 支持多种颜色空间：
 
 ```kotlin
 ColorPicker(
-    initialColor = Color(0xFF4CAF50),
+    color = Color(0xFF4CAF50),
     onColorChanged = { /* 处理颜色变化 */ },
     colorSpace = ColorSpace.OKLCH
 )
@@ -156,7 +159,7 @@ ColorPicker(
 var currentColor by remember { mutableStateOf(Color.Red) }
 var hexValue by remember(currentColor) {
     mutableStateOf(
-            "#${(currentColor.red * 255).toInt().toString(16).padStart(2, '0').uppercase()}" +
+        "#${(currentColor.red * 255).toInt().toString(16).padStart(2, '0').uppercase()}" +
                 (currentColor.green * 255).toInt().toString(16).padStart(2, '0').uppercase() +
                 (currentColor.blue * 255).toInt().toString(16).padStart(2, '0').uppercase()
     )
@@ -174,7 +177,7 @@ Surface {
         )
         Spacer(modifier = Modifier.height(16.dp))
         ColorPicker(
-            initialColor = currentColor,
+            color = currentColor,
             onColorChanged = {
                 currentColor = it
                 hexValue = "#${(it.red * 255).toInt().toString(16).padStart(2, '0').uppercase()}" +
@@ -201,7 +204,7 @@ Surface {
 var showColorDialog = remember { mutableStateOf(false) }
 var selectedColor by remember { mutableStateOf(Color.Red) }
 
-Scaffold { 
+Scaffold {
     TextButton(
         text = "选择颜色",
         onClick = { showColorDialog.value = true }
@@ -213,7 +216,7 @@ Scaffold {
     ) {
         Column {
             ColorPicker(
-                initialColor = selectedColor,
+                color = selectedColor,
                 onColorChanged = { selectedColor = it }
             )
             Spacer(modifier = Modifier.height(16.dp))

--- a/example/ios/iosApp/Info.plist
+++ b/example/ios/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.8</string>
 	<key>CFBundleVersion</key>
-	<string>750</string>
+	<string>751</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>

--- a/example/shared/src/commonMain/kotlin/SettingsPage.kt
+++ b/example/shared/src/commonMain/kotlin/SettingsPage.kt
@@ -285,7 +285,7 @@ fun SettingsContent(
             top = padding.calculateTopPadding(),
             bottom = if (isWideScreen) {
                 WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() +
-                        padding.calculateBottomPadding() + 12.dp
+                    padding.calculateBottomPadding() + 12.dp
             } else {
                 padding.calculateBottomPadding() + 12.dp
             },
@@ -434,7 +434,7 @@ fun AboutPage(
             top = padding.calculateTopPadding(),
             bottom = if (isWideScreen) {
                 WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() +
-                        padding.calculateBottomPadding() + 12.dp
+                    padding.calculateBottomPadding() + 12.dp
             } else {
                 padding.calculateBottomPadding() + 12.dp
             },

--- a/example/shared/src/commonMain/kotlin/component/OtherComponent.kt
+++ b/example/shared/src/commonMain/kotlin/component/OtherComponent.kt
@@ -568,7 +568,7 @@ fun LazyListScope.otherComponent() {
         var selectedColor by remember { mutableStateOf(miuixColor) }
         var colorHex by remember(selectedColor) {
             mutableStateOf(
-                selectedColor.toArgb().toHexString(HexFormat.UpperCase)
+                selectedColor.toArgb().toHexString(HexFormat.UpperCase),
             )
         }
 
@@ -585,9 +585,9 @@ fun LazyListScope.otherComponent() {
             ) {
                 Text(
                     text = "RGBA: ${(selectedColor.red * 255).toInt()}, " +
-                            "${(selectedColor.green * 255).toInt()}, " +
-                            "${(selectedColor.blue * 255).toInt()}, " +
-                            "${(round(selectedColor.alpha * 100) / 100.0)}",
+                        "${(selectedColor.green * 255).toInt()}, " +
+                        "${(selectedColor.blue * 255).toInt()}, " +
+                        "${(round(selectedColor.alpha * 100) / 100.0)}",
                     modifier = Modifier.weight(1f),
                 )
             }
@@ -611,10 +611,10 @@ fun LazyListScope.otherComponent() {
                     Text(
                         "HEX: #",
                         textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(start = 16.dp)
+                        modifier = Modifier.padding(start = 16.dp),
                     )
                 },
-                modifier = Modifier.padding(top = 12.dp)
+                modifier = Modifier.padding(top = 12.dp),
             )
         }
     }
@@ -625,7 +625,7 @@ fun LazyListScope.otherComponent() {
         var selectedColor by remember { mutableStateOf(miuixColor) }
         var colorHex by remember(selectedColor) {
             mutableStateOf(
-                selectedColor.toArgb().toHexString(HexFormat.UpperCase)
+                selectedColor.toArgb().toHexString(HexFormat.UpperCase),
             )
         }
 
@@ -643,9 +643,9 @@ fun LazyListScope.otherComponent() {
             ) {
                 Text(
                     text = "RGBA: ${(selectedColor.red * 255).toInt()}, " +
-                            "${(selectedColor.green * 255).toInt()}, " +
-                            "${(selectedColor.blue * 255).toInt()}, " +
-                            "${(round(selectedColor.alpha * 100) / 100.0)}",
+                        "${(selectedColor.green * 255).toInt()}, " +
+                        "${(selectedColor.blue * 255).toInt()}, " +
+                        "${(round(selectedColor.alpha * 100) / 100.0)}",
                     modifier = Modifier.weight(1f),
                 )
             }
@@ -670,10 +670,10 @@ fun LazyListScope.otherComponent() {
                     Text(
                         "HEX: #",
                         textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(start = 16.dp)
+                        modifier = Modifier.padding(start = 16.dp),
                     )
                 },
-                modifier = Modifier.padding(top = 12.dp)
+                modifier = Modifier.padding(top = 12.dp),
             )
         }
     }
@@ -684,7 +684,7 @@ fun LazyListScope.otherComponent() {
         var selectedColor by remember { mutableStateOf(miuixColor) }
         var colorHex by remember(selectedColor) {
             mutableStateOf(
-                selectedColor.toArgb().toHexString(HexFormat.UpperCase)
+                selectedColor.toArgb().toHexString(HexFormat.UpperCase),
             )
         }
 
@@ -701,9 +701,9 @@ fun LazyListScope.otherComponent() {
             ) {
                 Text(
                     text = "RGBA: ${(selectedColor.red * 255).toInt()}, " +
-                            "${(selectedColor.green * 255).toInt()}, " +
-                            "${(selectedColor.blue * 255).toInt()}, " +
-                            "${(round(selectedColor.alpha * 100) / 100.0)}",
+                        "${(selectedColor.green * 255).toInt()}, " +
+                        "${(selectedColor.blue * 255).toInt()}, " +
+                        "${(round(selectedColor.alpha * 100) / 100.0)}",
                     modifier = Modifier.weight(1f),
                 )
             }
@@ -728,10 +728,10 @@ fun LazyListScope.otherComponent() {
                     Text(
                         "HEX: #",
                         textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(start = 16.dp)
+                        modifier = Modifier.padding(start = 16.dp),
                     )
                 },
-                modifier = Modifier.padding(top = 12.dp)
+                modifier = Modifier.padding(top = 12.dp),
             )
         }
     }
@@ -742,7 +742,7 @@ fun LazyListScope.otherComponent() {
         var selectedColor by remember { mutableStateOf(miuixColor) }
         var colorHex by remember(selectedColor) {
             mutableStateOf(
-                selectedColor.toArgb().toHexString(HexFormat.UpperCase)
+                selectedColor.toArgb().toHexString(HexFormat.UpperCase),
             )
         }
 
@@ -760,9 +760,9 @@ fun LazyListScope.otherComponent() {
             ) {
                 Text(
                     text = "RGBA: ${(selectedColor.red * 255).toInt()}, " +
-                            "${(selectedColor.green * 255).toInt()}, " +
-                            "${(selectedColor.blue * 255).toInt()}, " +
-                            "${(round(selectedColor.alpha * 100) / 100.0)}",
+                        "${(selectedColor.green * 255).toInt()}, " +
+                        "${(selectedColor.blue * 255).toInt()}, " +
+                        "${(round(selectedColor.alpha * 100) / 100.0)}",
                     modifier = Modifier.weight(1f),
                 )
             }
@@ -787,10 +787,10 @@ fun LazyListScope.otherComponent() {
                     Text(
                         "HEX: #",
                         textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(start = 16.dp)
+                        modifier = Modifier.padding(start = 16.dp),
                     )
                 },
-                modifier = Modifier.padding(top = 12.dp)
+                modifier = Modifier.padding(top = 12.dp),
             )
         }
     }
@@ -801,7 +801,7 @@ fun LazyListScope.otherComponent() {
         var selectedColor by remember { mutableStateOf(miuixColor) }
         var colorHex by remember(selectedColor) {
             mutableStateOf(
-                selectedColor.toArgb().toHexString(HexFormat.UpperCase)
+                selectedColor.toArgb().toHexString(HexFormat.UpperCase),
             )
         }
 
@@ -818,9 +818,9 @@ fun LazyListScope.otherComponent() {
             ) {
                 Text(
                     text = "RGBA: ${(selectedColor.red * 255).toInt()}, " +
-                            "${(selectedColor.green * 255).toInt()}, " +
-                            "${(selectedColor.blue * 255).toInt()}, " +
-                            "${(round(selectedColor.alpha * 100) / 100.0)}",
+                        "${(selectedColor.green * 255).toInt()}, " +
+                        "${(selectedColor.blue * 255).toInt()}, " +
+                        "${(round(selectedColor.alpha * 100) / 100.0)}",
                     modifier = Modifier.weight(1f),
                 )
             }
@@ -844,10 +844,10 @@ fun LazyListScope.otherComponent() {
                     Text(
                         "HEX: #",
                         textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(start = 16.dp)
+                        modifier = Modifier.padding(start = 16.dp),
                     )
                 },
-                modifier = Modifier.padding(top = 12.dp)
+                modifier = Modifier.padding(top = 12.dp),
             )
         }
     }

--- a/example/shared/src/commonMain/kotlin/component/OtherComponent.kt
+++ b/example/shared/src/commonMain/kotlin/component/OtherComponent.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
@@ -565,6 +566,11 @@ fun LazyListScope.otherComponent() {
         SmallTitle(text = "ColorPicker (HSV)")
         val miuixColor = MiuixTheme.colorScheme.primary
         var selectedColor by remember { mutableStateOf(miuixColor) }
+        var colorHex by remember(selectedColor) {
+            mutableStateOf(
+                selectedColor.toArgb().toHexString(HexFormat.UpperCase)
+            )
+        }
 
         Card(
             modifier = Modifier
@@ -578,18 +584,37 @@ fun LazyListScope.otherComponent() {
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = "HEX: #${selectedColor.toArgb().toHexString(HexFormat.UpperCase)}" +
-                        "\nRGBA: ${(selectedColor.red * 255).toInt()}, " +
-                        "${(selectedColor.green * 255).toInt()}, " +
-                        "${(selectedColor.blue * 255).toInt()}, " +
-                        "${(round(selectedColor.alpha * 100) / 100.0)}",
+                    text = "RGBA: ${(selectedColor.red * 255).toInt()}, " +
+                            "${(selectedColor.green * 255).toInt()}, " +
+                            "${(selectedColor.blue * 255).toInt()}, " +
+                            "${(round(selectedColor.alpha * 100) / 100.0)}",
                     modifier = Modifier.weight(1f),
                 )
             }
             ColorPicker(
-                initialColor = selectedColor,
+                color = selectedColor,
                 onColorChanged = { selectedColor = it },
                 showPreview = false,
+            )
+            TextField(
+                value = colorHex,
+                onValueChange = { newHex ->
+                    if (newHex.length <= 8 && newHex.all { it.isDigit() || it in 'a'..'f' || it in 'A'..'F' }) {
+                        colorHex = newHex.uppercase()
+                        if (newHex.length == 8) {
+                            val newColor = Color(colorHex.toUInt(16).toInt())
+                            selectedColor = newColor
+                        }
+                    }
+                },
+                leadingIcon = {
+                    Text(
+                        "HEX: #",
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(start = 16.dp)
+                    )
+                },
+                modifier = Modifier.padding(top = 12.dp)
             )
         }
     }
@@ -598,6 +623,11 @@ fun LazyListScope.otherComponent() {
         SmallTitle(text = "ColorPicker (OKHSV)")
         val miuixColor = MiuixTheme.colorScheme.primary
         var selectedColor by remember { mutableStateOf(miuixColor) }
+        var colorHex by remember(selectedColor) {
+            mutableStateOf(
+                selectedColor.toArgb().toHexString(HexFormat.UpperCase)
+            )
+        }
 
         Card(
             modifier = Modifier
@@ -612,19 +642,38 @@ fun LazyListScope.otherComponent() {
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = "HEX: #${selectedColor.toArgb().toHexString(HexFormat.UpperCase)}" +
-                        "\nRGBA: ${(selectedColor.red * 255).toInt()}, " +
-                        "${(selectedColor.green * 255).toInt()}, " +
-                        "${(selectedColor.blue * 255).toInt()}, " +
-                        "${(round(selectedColor.alpha * 100) / 100.0)}",
+                    text = "RGBA: ${(selectedColor.red * 255).toInt()}, " +
+                            "${(selectedColor.green * 255).toInt()}, " +
+                            "${(selectedColor.blue * 255).toInt()}, " +
+                            "${(round(selectedColor.alpha * 100) / 100.0)}",
                     modifier = Modifier.weight(1f),
                 )
             }
             ColorPicker(
-                initialColor = selectedColor,
+                color = selectedColor,
                 onColorChanged = { selectedColor = it },
                 colorSpace = ColorSpace.OKHSV,
                 showPreview = false,
+            )
+            TextField(
+                value = colorHex,
+                onValueChange = { newHex ->
+                    if (newHex.length <= 8 && newHex.all { it.isDigit() || it in 'a'..'f' || it in 'A'..'F' }) {
+                        colorHex = newHex.uppercase()
+                        if (newHex.length == 8) {
+                            val newColor = Color(colorHex.toUInt(16).toInt())
+                            selectedColor = newColor
+                        }
+                    }
+                },
+                leadingIcon = {
+                    Text(
+                        "HEX: #",
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(start = 16.dp)
+                    )
+                },
+                modifier = Modifier.padding(top = 12.dp)
             )
         }
     }
@@ -633,6 +682,11 @@ fun LazyListScope.otherComponent() {
         SmallTitle(text = "ColorPicker (OKLAB)")
         val miuixColor = MiuixTheme.colorScheme.primary
         var selectedColor by remember { mutableStateOf(miuixColor) }
+        var colorHex by remember(selectedColor) {
+            mutableStateOf(
+                selectedColor.toArgb().toHexString(HexFormat.UpperCase)
+            )
+        }
 
         Card(
             modifier = Modifier
@@ -646,19 +700,38 @@ fun LazyListScope.otherComponent() {
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = "HEX: #${selectedColor.toArgb().toHexString(HexFormat.UpperCase)}" +
-                        "\nRGBA: ${(selectedColor.red * 255).toInt()}, " +
-                        "${(selectedColor.green * 255).toInt()}, " +
-                        "${(selectedColor.blue * 255).toInt()}, " +
-                        "${(round(selectedColor.alpha * 100) / 100.0)}",
+                    text = "RGBA: ${(selectedColor.red * 255).toInt()}, " +
+                            "${(selectedColor.green * 255).toInt()}, " +
+                            "${(selectedColor.blue * 255).toInt()}, " +
+                            "${(round(selectedColor.alpha * 100) / 100.0)}",
                     modifier = Modifier.weight(1f),
                 )
             }
             ColorPicker(
-                initialColor = selectedColor,
+                color = selectedColor,
                 onColorChanged = { selectedColor = it },
                 colorSpace = ColorSpace.OKLAB,
                 showPreview = false,
+            )
+            TextField(
+                value = colorHex,
+                onValueChange = { newHex ->
+                    if (newHex.length <= 8 && newHex.all { it.isDigit() || it in 'a'..'f' || it in 'A'..'F' }) {
+                        colorHex = newHex.uppercase()
+                        if (newHex.length == 8) {
+                            val newColor = Color(colorHex.toUInt(16).toInt())
+                            selectedColor = newColor
+                        }
+                    }
+                },
+                leadingIcon = {
+                    Text(
+                        "HEX: #",
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(start = 16.dp)
+                    )
+                },
+                modifier = Modifier.padding(top = 12.dp)
             )
         }
     }
@@ -667,6 +740,11 @@ fun LazyListScope.otherComponent() {
         SmallTitle(text = "ColorPicker (OKLCH)")
         val miuixColor = MiuixTheme.colorScheme.primary
         var selectedColor by remember { mutableStateOf(miuixColor) }
+        var colorHex by remember(selectedColor) {
+            mutableStateOf(
+                selectedColor.toArgb().toHexString(HexFormat.UpperCase)
+            )
+        }
 
         Card(
             modifier = Modifier
@@ -681,19 +759,38 @@ fun LazyListScope.otherComponent() {
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = "HEX: #${selectedColor.toArgb().toHexString(HexFormat.UpperCase)}" +
-                        "\nRGBA: ${(selectedColor.red * 255).toInt()}, " +
-                        "${(selectedColor.green * 255).toInt()}, " +
-                        "${(selectedColor.blue * 255).toInt()}, " +
-                        "${(round(selectedColor.alpha * 100) / 100.0)}",
+                    text = "RGBA: ${(selectedColor.red * 255).toInt()}, " +
+                            "${(selectedColor.green * 255).toInt()}, " +
+                            "${(selectedColor.blue * 255).toInt()}, " +
+                            "${(round(selectedColor.alpha * 100) / 100.0)}",
                     modifier = Modifier.weight(1f),
                 )
             }
             ColorPicker(
-                initialColor = selectedColor,
+                color = selectedColor,
                 onColorChanged = { selectedColor = it },
                 colorSpace = ColorSpace.OKLCH,
                 showPreview = false,
+            )
+            TextField(
+                value = colorHex,
+                onValueChange = { newHex ->
+                    if (newHex.length <= 8 && newHex.all { it.isDigit() || it in 'a'..'f' || it in 'A'..'F' }) {
+                        colorHex = newHex.uppercase()
+                        if (newHex.length == 8) {
+                            val newColor = Color(colorHex.toUInt(16).toInt())
+                            selectedColor = newColor
+                        }
+                    }
+                },
+                leadingIcon = {
+                    Text(
+                        "HEX: #",
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(start = 16.dp)
+                    )
+                },
+                modifier = Modifier.padding(top = 12.dp)
             )
         }
     }
@@ -702,6 +799,11 @@ fun LazyListScope.otherComponent() {
         SmallTitle(text = "ColorPalette")
         val miuixColor = MiuixTheme.colorScheme.primary
         var selectedColor by remember { mutableStateOf(miuixColor) }
+        var colorHex by remember(selectedColor) {
+            mutableStateOf(
+                selectedColor.toArgb().toHexString(HexFormat.UpperCase)
+            )
+        }
 
         Card(
             modifier = Modifier
@@ -715,18 +817,37 @@ fun LazyListScope.otherComponent() {
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = "HEX: #${selectedColor.toArgb().toHexString(HexFormat.UpperCase)}" +
-                        "\nRGBA: ${(selectedColor.red * 255).toInt()}, " +
-                        "${(selectedColor.green * 255).toInt()}, " +
-                        "${(selectedColor.blue * 255).toInt()}, " +
-                        "${(round(selectedColor.alpha * 100) / 100.0)}",
+                    text = "RGBA: ${(selectedColor.red * 255).toInt()}, " +
+                            "${(selectedColor.green * 255).toInt()}, " +
+                            "${(selectedColor.blue * 255).toInt()}, " +
+                            "${(round(selectedColor.alpha * 100) / 100.0)}",
                     modifier = Modifier.weight(1f),
                 )
             }
             ColorPalette(
-                initialColor = selectedColor,
+                color = selectedColor,
                 onColorChanged = { selectedColor = it },
                 showPreview = false,
+            )
+            TextField(
+                value = colorHex,
+                onValueChange = { newHex ->
+                    if (newHex.length <= 8 && newHex.all { it.isDigit() || it in 'a'..'f' || it in 'A'..'F' }) {
+                        colorHex = newHex.uppercase()
+                        if (newHex.length == 8) {
+                            val newColor = Color(colorHex.toUInt(16).toInt())
+                            selectedColor = newColor
+                        }
+                    }
+                },
+                leadingIcon = {
+                    Text(
+                        "HEX: #",
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(start = 16.dp)
+                    )
+                },
+                modifier = Modifier.padding(top = 12.dp)
             )
         }
     }

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/ColorPalette.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/ColorPalette.kt
@@ -51,7 +51,7 @@ import kotlin.math.roundToInt
 /**
  * A color palette component that allows users to select colors from a grid of HSV values.
  *
- * @param initialColor The initial color to display in the palette.
+ * @param color The color to display in the palette.
  * @param onColorChanged Callback invoked when the selected color changes.
  * @param modifier Modifier for styling the palette.
  * @param rows Number of rows in the color grid.
@@ -63,7 +63,7 @@ import kotlin.math.roundToInt
  */
 @Composable
 fun ColorPalette(
-    initialColor: Color,
+    color: Color,
     onColorChanged: (Color) -> Unit,
     modifier: Modifier = Modifier,
     rows: Int = 7,
@@ -80,17 +80,17 @@ fun ColorPalette(
 
     var selectedRow by remember { mutableIntStateOf(0) }
     var selectedCol by remember { mutableIntStateOf(0) }
-    var alpha by remember { mutableStateOf(initialColor.alpha.coerceIn(0f, 1f)) }
+    var alpha by remember { mutableStateOf(color.alpha.coerceIn(0f, 1f)) }
     var lastEmittedColor by remember { mutableStateOf<Color?>(null) }
     var lastAcceptedHSV by remember { mutableStateOf<Triple<Float, Float, Float>?>(null) }
-    LaunchedEffect(initialColor, rows, hueColumns, includeGrayColumn) {
-        val hsvInit = initialColor.toHsv()
+    LaunchedEffect(color, rows, hueColumns, includeGrayColumn) {
+        val hsvInit = color.toHsv()
         val h = hsvInit.h.toFloat()
         val s = (hsvInit.s / 100.0).toFloat()
         val v = (hsvInit.v / 100.0).toFloat()
         val currentHSV = Triple(h, s, v)
         if (lastAcceptedHSV?.let { hsvEqualApprox(it, currentHSV) } == true) {
-            alpha = initialColor.alpha
+            alpha = color.alpha
             lastAcceptedHSV = currentHSV
             return@LaunchedEffect
         }
@@ -109,7 +109,7 @@ fun ColorPalette(
         }
         selectedCol = col
         selectedRow = row
-        alpha = initialColor.alpha
+        alpha = color.alpha
         lastAcceptedHSV = currentHSV
     }
 
@@ -126,7 +126,7 @@ fun ColorPalette(
                     .fillMaxWidth()
                     .height(26.dp)
                     .clip(ContinuousCapsule)
-                    .background(lastEmittedColor ?: initialColor),
+                    .background(lastEmittedColor ?: color),
             )
         }
 

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/ColorPicker.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/ColorPicker.kt
@@ -16,10 +16,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
@@ -141,42 +141,31 @@ fun HsvColorPicker(
     var currentSaturation by remember { mutableFloatStateOf((hsv.s / 100.0).toFloat()) }
     var currentValue by remember { mutableFloatStateOf((hsv.v / 100.0).toFloat()) }
     var currentAlpha by remember { mutableFloatStateOf(color.alpha) }
-    var selectedColor = remember {
-        Hsv(
-            h = currentHue.toDouble(),
-            s = (currentSaturation * 100.0),
-            v = (currentValue * 100.0),
-        ).toColor(currentAlpha)
+
+    val selectedColor by remember {
+        derivedStateOf {
+            Hsv(
+                h = currentHue.toDouble(),
+                s = (currentSaturation * 100.0),
+                v = (currentValue * 100.0),
+            ).toColor(currentAlpha)
+        }
     }
 
-    var doNotCallback by remember { mutableStateOf(false) }
-    var isProgrammaticChange by remember { mutableStateOf(false) }
-
-    LaunchedEffect(color) {
-        if (!isProgrammaticChange) {
-            doNotCallback = true
+    SideEffect {
+        if (color.toArgb() != selectedColor.toArgb()) {
             val hsv = color.toHsv()
             currentHue = hsv.h.toFloat()
             currentSaturation = (hsv.s / 100.0).toFloat()
             currentValue = (hsv.v / 100.0).toFloat()
             currentAlpha = color.alpha
-            doNotCallback = false
         }
-        isProgrammaticChange = false
     }
 
-    LaunchedEffect(currentHue, currentSaturation, currentValue, currentAlpha) {
-        selectedColor = Hsv(
-            h = currentHue.toDouble(),
-            s = (currentSaturation * 100.0),
-            v = (currentValue * 100.0),
-        ).toColor(currentAlpha)
-
-        if (!doNotCallback) {
-            if (selectedColor.toArgb() != color.toArgb()) {
-                isProgrammaticChange = true
-                currentOnColorChanged(selectedColor)
-            }
+    fun notifyUserColorChanged() {
+        val newColor = selectedColor
+        if (newColor.toArgb() != color.toArgb()) {
+            currentOnColorChanged(newColor)
         }
     }
 
@@ -198,7 +187,10 @@ fun HsvColorPicker(
         // Hue selection
         HsvHueSlider(
             currentHue = currentHue,
-            onHueChanged = { newHue -> currentHue = newHue * 360f },
+            onHueChanged = { newHue ->
+                currentHue = newHue * 360f
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
 
@@ -206,7 +198,10 @@ fun HsvColorPicker(
         HsvSaturationSlider(
             currentHue = currentHue,
             currentSaturation = currentSaturation,
-            onSaturationChanged = { currentSaturation = it },
+            onSaturationChanged = {
+                currentSaturation = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
 
@@ -215,7 +210,10 @@ fun HsvColorPicker(
             currentHue = currentHue,
             currentSaturation = currentSaturation,
             currentValue = currentValue,
-            onValueChanged = { currentValue = it },
+            onValueChanged = {
+                currentValue = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
 
@@ -225,7 +223,10 @@ fun HsvColorPicker(
             currentSaturation = currentSaturation,
             currentValue = currentValue,
             currentAlpha = currentAlpha,
-            onAlphaChanged = { currentAlpha = it },
+            onAlphaChanged = {
+                currentAlpha = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
     }
@@ -377,42 +378,31 @@ fun OkHsvColorPicker(
     var currentS by remember { mutableFloatStateOf(okhsv[1]) }
     var currentV by remember { mutableFloatStateOf(okhsv[2]) }
     var currentAlpha by remember { mutableFloatStateOf(color.alpha) }
-    var selectedColor = remember {
-        OkHsv(
-            h = currentH,
-            s = currentS,
-            v = currentV,
-        ).toColor(currentAlpha)
+
+    val selectedColor by remember {
+        derivedStateOf {
+            OkHsv(
+                h = currentH,
+                s = currentS,
+                v = currentV,
+            ).toColor(currentAlpha)
+        }
     }
 
-    var doNotCallback by remember { mutableStateOf(false) }
-    var isProgrammaticChange by remember { mutableStateOf(false) }
-
-    LaunchedEffect(color) {
-        if (!isProgrammaticChange) {
-            doNotCallback = true
+    SideEffect {
+        if (color.toArgb() != selectedColor.toArgb()) {
             val okhsv = Transforms.colorToOkhsv(color)
             currentH = okhsv[0]
             currentS = okhsv[1]
             currentV = okhsv[2]
             currentAlpha = color.alpha
-            doNotCallback = false
         }
-        isProgrammaticChange = false
     }
 
-    LaunchedEffect(currentH, currentS, currentV, currentAlpha) {
-        selectedColor = OkHsv(
-            h = currentH,
-            s = currentS,
-            v = currentV,
-        ).toColor(currentAlpha)
-
-        if (!doNotCallback) {
-            if (selectedColor.toArgb() != color.toArgb()) {
-                isProgrammaticChange = true
-                currentOnColorChanged(selectedColor)
-            }
+    fun notifyUserColorChanged() {
+        val newColor = selectedColor
+        if (newColor.toArgb() != color.toArgb()) {
+            currentOnColorChanged(newColor)
         }
     }
 
@@ -434,7 +424,10 @@ fun OkHsvColorPicker(
         // Hue selection (OkHSV)
         OkHsvHueSlider(
             currentH = currentH,
-            onHueChanged = { currentH = it },
+            onHueChanged = {
+                currentH = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
 
@@ -442,7 +435,10 @@ fun OkHsvColorPicker(
         OkHsvSaturationSlider(
             currentH = currentH,
             currentS = currentS,
-            onSaturationChanged = { currentS = it },
+            onSaturationChanged = {
+                currentS = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
 
@@ -451,7 +447,10 @@ fun OkHsvColorPicker(
             currentH = currentH,
             currentS = currentS,
             currentV = currentV,
-            onValueChanged = { currentV = it },
+            onValueChanged = {
+                currentV = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
 
@@ -461,7 +460,10 @@ fun OkHsvColorPicker(
             currentS = currentS,
             currentV = currentV,
             currentAlpha = currentAlpha,
-            onAlphaChanged = { currentAlpha = it },
+            onAlphaChanged = {
+                currentAlpha = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
     }
@@ -617,42 +619,31 @@ fun OkLabColorPicker(
     var currentA by remember { mutableFloatStateOf(((ok.a / 100.0) * 0.4).toFloat()) }
     var currentB by remember { mutableFloatStateOf(((ok.b / 100.0) * 0.4).toFloat()) }
     var currentAlpha by remember { mutableFloatStateOf(color.alpha) }
-    var selectedColor = remember {
-        OkLab(
-            l = (currentL * 100.0),
-            a = (currentA / 0.4 * 100.0),
-            b = (currentB / 0.4 * 100.0),
-        ).toColor(currentAlpha)
+
+    val selectedColor by remember {
+        derivedStateOf {
+            OkLab(
+                l = (currentL * 100.0),
+                a = (currentA / 0.4 * 100.0),
+                b = (currentB / 0.4 * 100.0),
+            ).toColor(currentAlpha)
+        }
     }
 
-    var doNotCallback by remember { mutableStateOf(false) }
-    var isProgrammaticChange by remember { mutableStateOf(false) }
-
-    LaunchedEffect(color) {
-        if (!isProgrammaticChange) {
-            doNotCallback = true
+    SideEffect {
+        if (color.toArgb() != selectedColor.toArgb()) {
             val ok = color.toOkLab()
             currentL = (ok.l / 100.0).toFloat()
             currentA = ((ok.a / 100.0) * 0.4).toFloat()
             currentB = ((ok.b / 100.0) * 0.4).toFloat()
             currentAlpha = color.alpha
-            doNotCallback = false
         }
-        isProgrammaticChange = false
     }
 
-    LaunchedEffect(currentL, currentA, currentB, currentAlpha) {
-        selectedColor = OkLab(
-            l = (currentL * 100.0),
-            a = (currentA / 0.4 * 100.0),
-            b = (currentB / 0.4 * 100.0),
-        ).toColor(currentAlpha)
-
-        if (!doNotCallback) {
-            if (selectedColor.toArgb() != color.toArgb()) {
-                isProgrammaticChange = true
-                currentOnColorChanged(selectedColor)
-            }
+    fun notifyUserColorChanged() {
+        val newColor = selectedColor
+        if (newColor.toArgb() != color.toArgb()) {
+            currentOnColorChanged(newColor)
         }
     }
 
@@ -676,7 +667,10 @@ fun OkLabColorPicker(
             currentL = currentL,
             currentA = currentA,
             currentB = currentB,
-            onLightnessChanged = { currentL = it },
+            onLightnessChanged = {
+                currentL = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
 
@@ -685,7 +679,10 @@ fun OkLabColorPicker(
             currentL = currentL,
             currentA = currentA,
             currentB = currentB,
-            onAChanged = { currentA = it },
+            onAChanged = {
+                currentA = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
 
@@ -694,7 +691,10 @@ fun OkLabColorPicker(
             currentL = currentL,
             currentA = currentA,
             currentB = currentB,
-            onBChanged = { currentB = it },
+            onBChanged = {
+                currentB = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
 
@@ -704,7 +704,10 @@ fun OkLabColorPicker(
             currentA = currentA,
             currentB = currentB,
             currentAlpha = currentAlpha,
-            onAlphaChanged = { currentAlpha = it },
+            onAlphaChanged = {
+                currentAlpha = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
     }
@@ -735,42 +738,31 @@ fun OkLchColorPicker(
     var currentC by remember { mutableFloatStateOf((oklch.c / 100.0).toFloat()) } // proportion 0..1 (scaled to 0..0.4 internally)
     var currentH by remember { mutableFloatStateOf((oklch.h / 360.0).toFloat()) } // normalized 0..1 (scaled to 360)
     var currentAlpha by remember { mutableFloatStateOf(color.alpha) }
-    var selectedColor = remember {
-        OkLch(
-            l = (currentL * 100.0),
-            c = (currentC * 100.0),
-            h = (currentH * 360.0),
-        ).toColor(currentAlpha)
+
+    val selectedColor by remember {
+        derivedStateOf {
+            OkLch(
+                l = (currentL * 100.0),
+                c = (currentC * 100.0),
+                h = (currentH * 360.0),
+            ).toColor(currentAlpha)
+        }
     }
 
-    var doNotCallback by remember { mutableStateOf(false) }
-    var isProgrammaticChange by remember { mutableStateOf(false) }
-
-    LaunchedEffect(color) {
-        if (!isProgrammaticChange) {
-            doNotCallback = true
+    SideEffect {
+        if (color.toArgb() != selectedColor.toArgb()) {
             val oklch = color.toOkLch()
             currentL = (oklch.l / 100.0).toFloat()
             currentC = (oklch.c / 100.0).toFloat()
             currentH = (oklch.h / 360.0).toFloat()
             currentAlpha = color.alpha
-            doNotCallback = false
         }
-        isProgrammaticChange = false
     }
 
-    LaunchedEffect(currentL, currentC, currentH, currentAlpha) {
-        selectedColor = OkLch(
-            l = (currentL * 100.0),
-            c = (currentC * 100.0),
-            h = (currentH * 360.0),
-        ).toColor(currentAlpha)
-
-        if (!doNotCallback) {
-            if (selectedColor.toArgb() != color.toArgb()) {
-                isProgrammaticChange = true
-                currentOnColorChanged(selectedColor)
-            }
+    fun notifyUserColorChanged() {
+        val newColor = selectedColor
+        if (newColor.toArgb() != color.toArgb()) {
+            currentOnColorChanged(newColor)
         }
     }
 
@@ -794,7 +786,10 @@ fun OkLchColorPicker(
             currentL = currentL,
             currentC = currentC,
             currentH = currentH,
-            onHueChanged = { currentH = it },
+            onHueChanged = {
+                currentH = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
 
@@ -803,7 +798,10 @@ fun OkLchColorPicker(
             currentL = currentL,
             currentC = currentC,
             currentH = currentH,
-            onLightnessChanged = { currentL = it },
+            onLightnessChanged = {
+                currentL = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
 
@@ -812,7 +810,10 @@ fun OkLchColorPicker(
             currentL = currentL,
             currentC = currentC,
             currentH = currentH,
-            onChromaChanged = { currentC = it },
+            onChromaChanged = {
+                currentC = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
 
@@ -822,7 +823,10 @@ fun OkLchColorPicker(
             currentC = currentC,
             currentH = currentH,
             currentAlpha = currentAlpha,
-            onAlphaChanged = { currentAlpha = it },
+            onAlphaChanged = {
+                currentAlpha = it
+                notifyUserColorChanged()
+            },
             hapticEffect = hapticEffect,
         )
     }


### PR DESCRIPTION
*   Rename the `initialColor` parameter to `color` in `ColorPicker` and `ColorPalette`. This makes them fully controlled components, reacting to external state changes.
*   The color picker state now updates when the input `color` prop changes.

example: Add HEX color input to ColorPicker demo

*   Add a `TextField` to allow users to input a HEX color value directly.