### PR TITLE
library: Refactor color spaces to use Float and fix update bugs

### DIFF
--- a/example/ios/iosApp/Info.plist
+++ b/example/ios/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.8</string>
 	<key>CFBundleVersion</key>
-	<string>753</string>
+	<string>754</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/ColorPalette.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/ColorPalette.kt
@@ -85,9 +85,9 @@ fun ColorPalette(
     var lastAcceptedHSV by remember { mutableStateOf<Triple<Float, Float, Float>?>(null) }
     LaunchedEffect(color, rows, hueColumns, includeGrayColumn) {
         val hsvInit = color.toHsv()
-        val h = hsvInit.h.toFloat()
-        val s = (hsvInit.s / 100.0).toFloat()
-        val v = (hsvInit.v / 100.0).toFloat()
+        val h = hsvInit.h
+        val s = hsvInit.s / 100f
+        val v = hsvInit.v / 100f
         val currentHSV = Triple(h, s, v)
         if (lastAcceptedHSV?.let { hsvEqualApprox(it, currentHSV) } == true) {
             alpha = color.alpha
@@ -148,16 +148,16 @@ fun ColorPalette(
                 selectedRow = r
                 selectedCol = c
                 val newColor = cellColor(c, r, rowSV, grayV, hueColumns, includeGrayColumn).copy(alpha = alpha)
-                lastAcceptedHSV = newColor.toHsv().let { Triple(it.h.toFloat(), (it.s / 100.0).toFloat(), (it.v / 100.0).toFloat()) }
+                lastAcceptedHSV = newColor.toHsv().let { Triple(it.h, it.s / 100f, it.v / 100f) }
                 lastEmittedColor = newColor
                 onColorChangedState.value(newColor)
             },
         )
 
         val hsvBase = baseColor.toHsv()
-        val h = hsvBase.h.toFloat()
-        val s = (hsvBase.s / 100.0).toFloat()
-        val v = (hsvBase.v / 100.0).toFloat()
+        val h = hsvBase.h
+        val s = hsvBase.s / 100f
+        val v = hsvBase.v / 100f
 
         HsvAlphaSlider(
             currentHue = h,
@@ -168,7 +168,7 @@ fun ColorPalette(
                 alpha = it
                 val newColor = baseColor.copy(alpha = it)
                 lastAcceptedHSV =
-                    baseColor.toHsv().let { Triple(it.h.toFloat(), (it.s / 100.0).toFloat(), (it.v / 100.0).toFloat()) }
+                    baseColor.toHsv().let { Triple(it.h, it.s / 100f, it.v / 100f) }
                 lastEmittedColor = newColor
                 onColorChangedState.value(newColor)
             },
@@ -366,11 +366,11 @@ private fun cellColor(
     val totalColumns = hueColumns + if (includeGrayColumn) 1 else 0
     val (s, v) = rowSV[row]
     return if (includeGrayColumn && col == totalColumns - 1) {
-        Hsv(0.0, 0.0, (grayV[row] * 100.0)).toColor()
+        Hsv(0f, 0f, grayV[row] * 100f).toColor()
     } else {
         val step = 360f / hueColumns
         val h = (col * step) % 360f
-        Hsv(h.toDouble(), (s * 100.0), (v * 100.0)).toColor()
+        Hsv(h, s * 100f, v * 100f).toColor()
     }
 }
 

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/ColorPicker.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/ColorPicker.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
@@ -137,27 +138,37 @@ fun HsvColorPicker(
 
     // Initialize basic values, execute only once.
     val hsv = remember { color.toHsv() }
-    var currentHue by remember { mutableFloatStateOf(hsv.h.toFloat()) }
-    var currentSaturation by remember { mutableFloatStateOf((hsv.s / 100.0).toFloat()) }
-    var currentValue by remember { mutableFloatStateOf((hsv.v / 100.0).toFloat()) }
+    var currentHue by remember { mutableFloatStateOf(hsv.h) }
+    var currentSaturation by remember { mutableFloatStateOf(hsv.s / 100f) }
+    var currentValue by remember { mutableFloatStateOf(hsv.v / 100f) }
     var currentAlpha by remember { mutableFloatStateOf(color.alpha) }
 
+    var lastAppliedExternalColorArgb by remember {
+        mutableStateOf(color.toArgb())
+    }
     val selectedColor by remember {
         derivedStateOf {
             Hsv(
-                h = currentHue.toDouble(),
-                s = (currentSaturation * 100.0),
-                v = (currentValue * 100.0),
+                h = currentHue,
+                s = currentSaturation * 100f,
+                v = currentValue * 100f,
             ).toColor(currentAlpha)
         }
     }
 
     SideEffect {
-        if (color.toArgb() != selectedColor.toArgb()) {
+        val externalArgb = color.toArgb()
+        val internalArgb = selectedColor.toArgb()
+
+        if (
+            externalArgb != lastAppliedExternalColorArgb &&
+            externalArgb != internalArgb
+        ) {
+            lastAppliedExternalColorArgb = externalArgb
             val hsv = color.toHsv()
-            currentHue = hsv.h.toFloat()
-            currentSaturation = (hsv.s / 100.0).toFloat()
-            currentValue = (hsv.v / 100.0).toFloat()
+            currentHue = hsv.h
+            currentSaturation = hsv.s / 100f
+            currentValue = hsv.v / 100f
             currentAlpha = color.alpha
         }
     }
@@ -275,8 +286,8 @@ fun HsvSaturationSlider(
 ) {
     val saturationColors = remember(currentHue) {
         listOf(
-            Hsv(currentHue.toDouble(), 0.0, 100.0).toColor(1f),
-            Hsv(currentHue.toDouble(), 100.0, 100.0).toColor(1f),
+            Hsv(currentHue, 0f, 100f).toColor(1f),
+            Hsv(currentHue, 100f, 100f).toColor(1f),
         )
     }
     ColorSlider(
@@ -306,7 +317,7 @@ fun HsvValueSlider(
     hapticEffect: SliderDefaults.SliderHapticEffect = SliderDefaults.DefaultHapticEffect,
 ) {
     val valueColors = remember(currentHue, currentSaturation) {
-        listOf(Color.Black, Hsv(currentHue.toDouble(), (currentSaturation * 100.0), 100.0).toColor())
+        listOf(Color.Black, Hsv(currentHue, currentSaturation * 100f, 100f).toColor())
     }
     ColorSlider(
         value = currentValue,
@@ -337,7 +348,7 @@ fun HsvAlphaSlider(
     hapticEffect: SliderDefaults.SliderHapticEffect = SliderDefaults.DefaultHapticEffect,
 ) {
     val alphaColors = remember(currentHue, currentSaturation, currentValue) {
-        val baseColor = Hsv(currentHue.toDouble(), (currentSaturation * 100.0), (currentValue * 100.0)).toColor()
+        val baseColor = Hsv(currentHue, currentSaturation * 100f, currentValue * 100f).toColor()
         listOf(baseColor.copy(alpha = 0f), baseColor.copy(alpha = 1f))
     }
 
@@ -379,6 +390,9 @@ fun OkHsvColorPicker(
     var currentV by remember { mutableFloatStateOf(okhsv[2]) }
     var currentAlpha by remember { mutableFloatStateOf(color.alpha) }
 
+    var lastAppliedExternalColorArgb by remember {
+        mutableStateOf(color.toArgb())
+    }
     val selectedColor by remember {
         derivedStateOf {
             OkHsv(
@@ -390,7 +404,14 @@ fun OkHsvColorPicker(
     }
 
     SideEffect {
-        if (color.toArgb() != selectedColor.toArgb()) {
+        val externalArgb = color.toArgb()
+        val internalArgb = selectedColor.toArgb()
+
+        if (
+            externalArgb != lastAppliedExternalColorArgb &&
+            externalArgb != internalArgb
+        ) {
+            lastAppliedExternalColorArgb = externalArgb
             val okhsv = Transforms.colorToOkhsv(color)
             currentH = okhsv[0]
             currentS = okhsv[1]
@@ -615,27 +636,37 @@ fun OkLabColorPicker(
 
     // Initialize basic values, execute only once.
     val ok = remember { color.toOkLab() }
-    var currentL by remember { mutableFloatStateOf((ok.l / 100.0).toFloat()) }
-    var currentA by remember { mutableFloatStateOf(((ok.a / 100.0) * 0.4).toFloat()) }
-    var currentB by remember { mutableFloatStateOf(((ok.b / 100.0) * 0.4).toFloat()) }
+    var currentL by remember { mutableFloatStateOf(ok.l / 100f) }
+    var currentA by remember { mutableFloatStateOf(((ok.a / 100f) * 0.4f)) }
+    var currentB by remember { mutableFloatStateOf(((ok.b / 100f) * 0.4f)) }
     var currentAlpha by remember { mutableFloatStateOf(color.alpha) }
 
+    var lastAppliedExternalColorArgb by remember {
+        mutableStateOf(color.toArgb())
+    }
     val selectedColor by remember {
         derivedStateOf {
             OkLab(
-                l = (currentL * 100.0),
-                a = (currentA / 0.4 * 100.0),
-                b = (currentB / 0.4 * 100.0),
+                l = currentL * 100f,
+                a = (currentA / 0.4f) * 100f,
+                b = (currentB / 0.4f) * 100f,
             ).toColor(currentAlpha)
         }
     }
 
     SideEffect {
-        if (color.toArgb() != selectedColor.toArgb()) {
+        val externalArgb = color.toArgb()
+        val internalArgb = selectedColor.toArgb()
+
+        if (
+            externalArgb != lastAppliedExternalColorArgb &&
+            externalArgb != internalArgb
+        ) {
+            lastAppliedExternalColorArgb = externalArgb
             val ok = color.toOkLab()
-            currentL = (ok.l / 100.0).toFloat()
-            currentA = ((ok.a / 100.0) * 0.4).toFloat()
-            currentB = ((ok.b / 100.0) * 0.4).toFloat()
+            currentL = ok.l / 100f
+            currentA = (ok.a / 100f) * 0.4f
+            currentB = (ok.b / 100f) * 0.4f
             currentAlpha = color.alpha
         }
     }
@@ -734,27 +765,37 @@ fun OkLchColorPicker(
 
     // Initialize basic values, execute only once.
     val oklch = remember { color.toOkLch() }
-    var currentL by remember { mutableFloatStateOf((oklch.l / 100.0).toFloat()) } // 0..1
-    var currentC by remember { mutableFloatStateOf((oklch.c / 100.0).toFloat()) } // proportion 0..1 (scaled to 0..0.4 internally)
-    var currentH by remember { mutableFloatStateOf((oklch.h / 360.0).toFloat()) } // normalized 0..1 (scaled to 360)
+    var currentL by remember { mutableFloatStateOf(oklch.l / 100f) } // 0..1
+    var currentC by remember { mutableFloatStateOf(oklch.c / 100f) } // proportion 0..1 (scaled to 0..0.4 internally)
+    var currentH by remember { mutableFloatStateOf(oklch.h / 360f) } // normalized 0..1 (scaled to 360)
     var currentAlpha by remember { mutableFloatStateOf(color.alpha) }
 
+    var lastAppliedExternalColorArgb by remember {
+        mutableStateOf(color.toArgb())
+    }
     val selectedColor by remember {
         derivedStateOf {
             OkLch(
-                l = (currentL * 100.0),
-                c = (currentC * 100.0),
-                h = (currentH * 360.0),
+                l = currentL * 100f,
+                c = currentC * 100f,
+                h = currentH * 360f,
             ).toColor(currentAlpha)
         }
     }
 
     SideEffect {
-        if (color.toArgb() != selectedColor.toArgb()) {
+        val externalArgb = color.toArgb()
+        val internalArgb = selectedColor.toArgb()
+
+        if (
+            externalArgb != lastAppliedExternalColorArgb &&
+            externalArgb != internalArgb
+        ) {
+            lastAppliedExternalColorArgb = externalArgb
             val oklch = color.toOkLch()
-            currentL = (oklch.l / 100.0).toFloat()
-            currentC = (oklch.c / 100.0).toFloat()
-            currentH = (oklch.h / 360.0).toFloat()
+            currentL = oklch.l / 100f
+            currentC = oklch.c / 100f
+            currentH = oklch.h / 360f
             currentAlpha = color.alpha
         }
     }
@@ -948,9 +989,9 @@ fun OkLabLightnessSlider(
         (0..steps).map { i ->
             val l = i.toFloat() / steps.toFloat()
             OkLab(
-                l = l * 100.0,
-                a = (currentA / 0.4 * 100.0),
-                b = (currentB / 0.4 * 100.0),
+                l = l * 100f,
+                a = (currentA / 0.4f) * 100f,
+                b = (currentB / 0.4f) * 100f,
             ).toColor()
         }
     }
@@ -981,9 +1022,9 @@ fun OkLabAChannelSlider(
         (0..steps).map { i ->
             val a = minA + (maxA - minA) * i.toFloat() / steps.toFloat()
             OkLab(
-                l = currentL * 100.0,
-                a = (a / 0.4 * 100.0),
-                b = (currentB / 0.4 * 100.0),
+                l = currentL * 100f,
+                a = (a / 0.4f) * 100f,
+                b = (currentB / 0.4f) * 100f,
             ).toColor()
         }
     }
@@ -1016,9 +1057,9 @@ fun OkLabBChannelSlider(
         (0..steps).map { i ->
             val b = minB + (maxB - minB) * i.toFloat() / steps.toFloat()
             OkLab(
-                l = currentL * 100.0,
-                a = (currentA / 0.4 * 100.0),
-                b = (b / 0.4 * 100.0),
+                l = currentL * 100f,
+                a = (currentA / 0.4f) * 100f,
+                b = (b / 0.4f) * 100f,
             ).toColor()
         }
     }
@@ -1047,9 +1088,9 @@ fun OkLabAlphaSlider(
 ) {
     val alphaColors = remember(currentL, currentA, currentB) {
         val baseColor = OkLab(
-            l = currentL * 100.0,
-            a = (currentA / 0.4 * 100.0),
-            b = (currentB / 0.4 * 100.0),
+            l = currentL * 100f,
+            a = (currentA / 0.4f) * 100f,
+            b = (currentB / 0.4f) * 100f,
         ).toColor()
         listOf(baseColor.copy(alpha = 0f), baseColor.copy(alpha = 1f))
     }

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/color/api/Extensions.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/color/api/Extensions.kt
@@ -12,26 +12,26 @@ import top.yukonga.miuix.kmp.color.space.OkLch
 /** Convert Compose Color to user-friendly OkLab. */
 fun Color.toOkLab(): OkLab {
     val lab = Transforms.colorToOkLab(this)
-    val l = (lab[0] * 100.0).coerceIn(0.0, 100.0)
-    val a = (lab[1] / 0.4 * 100.0).coerceIn(-100.0, 100.0)
-    val b = (lab[2] / 0.4 * 100.0).coerceIn(-100.0, 100.0)
+    val l = (lab[0] * 100f).coerceIn(0f, 100f)
+    val a = (lab[1] / 0.4f * 100f).coerceIn(-100f, 100f)
+    val b = (lab[2] / 0.4f * 100f).coerceIn(-100f, 100f)
     return OkLab(l, a, b)
 }
 
 /** Convert Compose Color to Hvs. */
 fun Color.toHsv(): Hsv {
     val hsvArr = Transforms.colorToHsv(this)
-    val h = hsvArr[0].toDouble()
-    val s = (hsvArr[1] * 100.0).coerceIn(0.0, 100.0)
-    val v = (hsvArr[2] * 100.0).coerceIn(0.0, 100.0)
+    val h = hsvArr[0]
+    val s = (hsvArr[1] * 100f).coerceIn(0f, 100f)
+    val v = (hsvArr[2] * 100f).coerceIn(0f, 100f)
     return Hsv(h, s, v)
 }
 
 /** Convert Compose Color to user-friendly OkLch. */
 fun Color.toOkLch(): OkLch {
     val lch = Transforms.colorToOklch(this)
-    val l = (lch[0] * 100.0).coerceIn(0.0, 100.0)
-    val c = (lch[1] / 0.4 * 100.0).coerceIn(0.0, 100.0)
-    val h = lch[2].toDouble() // degrees already normalized
+    val l = (lch[0] * 100f).coerceIn(0f, 100f)
+    val c = (lch[1] / 0.4f * 100f).coerceIn(0f, 100f)
+    val h = lch[2] // degrees already normalized
     return OkLch(l, c, h)
 }

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/color/core/Transforms.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/color/core/Transforms.kt
@@ -442,8 +442,8 @@ object Transforms {
     fun generateHsvHueColors(): List<Color> {
         val steps = 36
         return (0 until steps).map { i ->
-            val hue = i.toDouble() / steps.toDouble() * 360.0
-            Hsv(hue, 100.0, 100.0).toColor()
+            val hue = i.toFloat() / steps.toFloat() * 360f
+            Hsv(hue, 100f, 100f).toColor()
         }
     }
 

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/color/space/Hsv.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/color/space/Hsv.kt
@@ -8,15 +8,15 @@ import androidx.compose.ui.graphics.Color.Companion.hsv
 
 /**
  * HSV representation with normalized, user-friendly ranges.
- * - `h`: hue in degrees [0, 360)
- * - `s`: saturation in percent [0.0, 100.0]
- * - `v`: value/brightness in percent [0.0, 100.0]
+ * - `h`: hue in degrees [0, 360]
+ * - `s`: saturation in percent [0, 100]
+ * - `v`: value/brightness in percent [0, 100]
  */
-data class Hsv(val h: Double, val s: Double, val v: Double) {
+data class Hsv(val h: Float, val s: Float, val v: Float) {
     fun toColor(alpha: Float = 1f): Color {
-        val hue = (((h % 360.0) + 360.0) % 360.0).toFloat()
-        val sN = (s / 100.0).coerceIn(0.0, 1.0).toFloat()
-        val vN = (v / 100.0).coerceIn(0.0, 1.0).toFloat()
+        val hue = (((h % 360f) + 360f) % 360f)
+        val sN = (s / 100f).coerceIn(0f, 1f)
+        val vN = (v / 100f).coerceIn(0f, 1f)
         return hsv(hue, sN, vN, alpha)
     }
 }

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/color/space/OkHsv.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/color/space/OkHsv.kt
@@ -8,9 +8,9 @@ import top.yukonga.miuix.kmp.color.core.Transforms
 
 /**
  * OkHSV representation with normalized, user-friendly ranges.
- * - `h`: hue in degrees [0, 360)
- * - `s`: saturation in percent [0.0, 100.0]
- * - `v`: value/brightness in percent [0.0, 100.0
+ * - `h`: hue in degrees [0, 360]
+ * - `s`: saturation in percent [0, 100]
+ * - `v`: value/brightness in percent [0, 100]
  */
 data class OkHsv(val h: Float, val s: Float, val v: Float) {
     fun toColor(alpha: Float = 1f): Color = Transforms.okhsvToColor(h, s, v, alpha)

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/color/space/OkLab.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/color/space/OkLab.kt
@@ -8,15 +8,15 @@ import top.yukonga.miuix.kmp.color.core.Transforms
 
 /**
  * OkLAB representation with normalized, user-friendly ranges.
- * - `l`: 0.0..100.0 (lightness percent)
- * - `a`: -100.0..100.0 (green-red axis, mapped to internal [-0.4, 0.4])
- * - `b`: -100.0..100.0 (blue-yellow axis, mapped to internal [-0.4, 0.4])
+ * - `l`: 0..100 (lightness percent)
+ * - `a`: -100..100 (green-red axis, mapped to internal [-0.4, 0.4])
+ * - `b`: -100..100 (blue-yellow axis, mapped to internal [-0.4, 0.4])
  */
-data class OkLab(val l: Double, val a: Double, val b: Double) {
+data class OkLab(val l: Float, val a: Float, val b: Float) {
     fun toColor(alpha: Float = 1f): Color {
-        val lN = (l / 100.0).coerceIn(0.0, 1.0).toFloat()
-        val aN = ((a / 100.0) * 0.4).toFloat().coerceIn(-0.4f, 0.4f)
-        val bN = ((b / 100.0) * 0.4).toFloat().coerceIn(-0.4f, 0.4f)
+        val lN = (l / 100f).coerceIn(0f, 1f)
+        val aN = ((a / 100f) * 0.4f).coerceIn(-0.4f, 0.4f)
+        val bN = ((b / 100f) * 0.4f).coerceIn(-0.4f, 0.4f)
         val ok = floatArrayOf(lN, aN, bN)
         return Transforms.okLabToColor(ok, alpha)
     }

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/color/space/OkLch.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/color/space/OkLch.kt
@@ -8,15 +8,15 @@ import top.yukonga.miuix.kmp.color.core.Transforms
 
 /**
  * OkLCH representation with normalized, user-friendly ranges.
- * - `l`: 0.0..100.0 (lightness percent)
- * - `c`: 0.0..100.0 (chroma percent, mapped to internal [0.0, 0.4])
- * - `h`: hue in degrees [0, 360)
+ * - `l`: 0..100 (lightness percent)
+ * - `c`: 0..100 (chroma percent, mapped to internal [0.0, 0.4])
+ * - `h`: hue in degrees [0, 360]
  */
-data class OkLch(val l: Double, val c: Double, val h: Double) {
+data class OkLch(val l: Float, val c: Float, val h: Float) {
     fun toColor(alpha: Float = 1f): Color {
-        val lN = (l / 100.0).coerceIn(0.0, 1.0).toFloat()
-        val cN = ((c / 100.0) * 0.4).toFloat().coerceIn(0f, 0.4f)
-        val hDeg = (((h % 360.0) + 360.0) % 360.0).toFloat()
+        val lN = (l / 100f).coerceIn(0f, 1f)
+        val cN = ((c / 100f) * 0.4f).coerceIn(0f, 0.4f)
+        val hDeg = (((h % 360f) + 360f) % 360f)
         return Transforms.oklchToColor(lN, cN, hDeg, alpha)
     }
 }


### PR DESCRIPTION
*   Refactor color space models (Hsv, OkHsv, OkLab, OkLch) and related extensions to use `Float` instead of `Double` for consistency and performance.
*   Fix a bug in `ColorPicker` where external color updates were not always reflected internally. The component now tracks the last externally applied color to prevent feedback loops and ensure state synchronization.
*   Update documentation comments for color space ranges.