### PR TITLE
fix: fix `fillMaxHeight()` causing components fill infinity height

### DIFF
--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperArrow.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperArrow.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -74,7 +73,6 @@ fun SuperArrow(
         endActions = {
             Row(
                 modifier = Modifier
-                    .fillMaxHeight()
                     .padding(end = 8.dp)
                     .align(Alignment.CenterVertically)
                     .weight(1f, fill = false),

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperCheckbox.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperCheckbox.kt
@@ -6,7 +6,6 @@ package top.yukonga.miuix.kmp.extra
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NonRestartableComposable
@@ -83,7 +82,6 @@ fun SuperCheckbox(
         endActions = {
             Row(
                 modifier = Modifier
-                    .fillMaxHeight()
                     .padding(end = 8.dp)
                     .align(Alignment.CenterVertically)
                     .weight(1f, fill = false),

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperDropdown.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperDropdown.kt
@@ -5,7 +5,6 @@ package top.yukonga.miuix.kmp.extra
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
@@ -108,7 +107,6 @@ fun SuperDropdown(
                 Text(
                     text = items[selectedIndex],
                     modifier = Modifier
-                        .fillMaxHeight()
                         .padding(end = 8.dp)
                         .align(Alignment.CenterVertically)
                         .weight(1f, fill = false),

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperSpinner.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperSpinner.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -130,7 +129,6 @@ fun SuperSpinner(
                 Text(
                     text = items[selectedIndex].title ?: "",
                     modifier = Modifier
-                        .fillMaxHeight()
                         .padding(end = 8.dp)
                         .align(Alignment.CenterVertically)
                         .weight(1f, fill = false),
@@ -277,7 +275,6 @@ fun SuperSpinner(
                 Text(
                     text = items[selectedIndex].title ?: "",
                     modifier = Modifier
-                        .fillMaxHeight()
                         .padding(end = 8.dp)
                         .align(Alignment.CenterVertically)
                         .weight(1f, fill = false),

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperSwitch.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperSwitch.kt
@@ -6,7 +6,6 @@ package top.yukonga.miuix.kmp.extra
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NonRestartableComposable
@@ -70,7 +69,6 @@ fun SuperSwitch(
         endActions = {
             Row(
                 modifier = Modifier
-                    .fillMaxHeight()
                     .padding(end = 8.dp)
                     .align(Alignment.CenterVertically)
                     .weight(1f, fill = false),

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/WindowDropdown.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/WindowDropdown.kt
@@ -5,7 +5,6 @@ package top.yukonga.miuix.kmp.extra
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
@@ -108,7 +107,6 @@ fun WindowDropdown(
                 Text(
                     text = items[selectedIndex],
                     modifier = Modifier
-                        .fillMaxHeight()
                         .padding(end = 8.dp)
                         .align(Alignment.CenterVertically)
                         .weight(1f, fill = false),

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/WindowSpinner.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/WindowSpinner.kt
@@ -5,7 +5,6 @@ package top.yukonga.miuix.kmp.extra
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -113,7 +112,6 @@ fun WindowSpinner(
                 Text(
                     text = items[selectedIndex].title ?: "",
                     modifier = Modifier
-                        .fillMaxHeight()
                         .padding(end = 8.dp)
                         .align(Alignment.CenterVertically)
                         .weight(1f, fill = false),
@@ -261,7 +259,6 @@ fun WindowSpinner(
                 Text(
                     text = items[selectedIndex].title ?: "",
                     modifier = Modifier
-                        .fillMaxHeight()
                         .padding(end = 8.dp)
                         .align(Alignment.CenterVertically)
                         .weight(1f, fill = false),


### PR DESCRIPTION
Removed `fillMaxHeight()` modifiers from `SuperDropdown`, `SuperSpinner`, `SuperArrow`, `SuperCheckbox`, `SuperSwitch`, `WindowDropdown`, and `WindowSpinner` as they already use `align(Alignment.CenterVertically)`.