### PR TITLE
library: Refactor predictive pop transition API and add inverse easing

### DIFF
--- a/miuix-navigation3-ui/src/commonMain/kotlin/androidx/navigation3/animation/NavTransitionEasing.kt
+++ b/miuix-navigation3-ui/src/commonMain/kotlin/androidx/navigation3/animation/NavTransitionEasing.kt
@@ -5,7 +5,9 @@ package androidx.navigation3.animation
 
 import androidx.compose.animation.core.Easing
 import androidx.compose.runtime.Immutable
+import kotlin.compareTo
 import kotlin.math.PI
+import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.exp
 import kotlin.math.sin
@@ -36,7 +38,7 @@ internal class NavTransitionEasing(
         return (decay * (-cos(w * t) + c2 * sin(w * t)) + 1.0).toFloat()
     }
 
-    fun inverseTransform(fraction: Float): Float {
+    fun inverseTransform(fraction: Float, tolerance: Float = 1e-6f): Float {
         if (fraction <= 0f) return 0f
         if (fraction >= 1f) return 1f
 
@@ -47,6 +49,8 @@ internal class NavTransitionEasing(
         repeat(16) {
             mid = (low + high) / 2f
             val value = transform(mid)
+            if (abs(value - fraction) < tolerance) return mid
+
             if (value < fraction) {
                 low = mid
             } else {

--- a/miuix-navigation3-ui/src/commonMain/kotlin/androidx/navigation3/ui/NavDisplay.kt
+++ b/miuix-navigation3-ui/src/commonMain/kotlin/androidx/navigation3/ui/NavDisplay.kt
@@ -683,7 +683,7 @@ fun <T : Any> NavDisplay(
             LocalLifecycleOwner provides sceneLifecycleOwner,
             LocalNavAnimatedContentScope provides this,
             LocalEntriesToExcludeFromCurrentScene provides
-                    sceneToExcludedEntryMap.getOrElse(sceneKeyOf(targetScene)) { emptySet() },
+                sceneToExcludedEntryMap.getOrElse(sceneKeyOf(targetScene)) { emptySet() },
         ) {
             val corner = if (Platform.Android == platform() && !isInMultiWindowMode()) getRoundedCorner() else 0.dp
             val shape = remember(corner) {
@@ -771,7 +771,7 @@ fun <T : Any> NavDisplay(
     overlayScenes.fastForEachReversed { overlayScene ->
         CompositionLocalProvider(
             LocalEntriesToExcludeFromCurrentScene provides
-                    sceneToExcludedEntryMap.getOrElse(sceneKeyOf(overlayScene)) { emptySet() },
+                sceneToExcludedEntryMap.getOrElse(sceneKeyOf(overlayScene)) { emptySet() },
         ) {
             overlayScene.content.invoke()
         }
@@ -825,22 +825,21 @@ fun <T : Any> defaultPopTransitionSpec(): AnimatedContentTransitionScope<Scene<T
 }
 
 /** Default [transitionSpec] for predictive pop navigation to be used by [NavDisplay]. */
-fun defaultPredictivePopTransitionSpec(): PredictivePopTransitionSpec =
-    PredictivePopTransitionSpec(
-        animationSpec = tween(durationMillis = 500, easing = NavAnimationEasing),
-        contentTransform = {
-            ContentTransform(
-                slideInHorizontally(
-                    initialOffsetX = { -it / 4 },
-                    animationSpec = tween(durationMillis = 550, easing = LinearEasing),
-                ),
-                slideOutHorizontally(
-                    targetOffsetX = { it },
-                    animationSpec = tween(durationMillis = 550, easing = LinearEasing),
-                ),
-            )
-        }
-    )
+fun defaultPredictivePopTransitionSpec(): PredictivePopTransitionSpec = PredictivePopTransitionSpec(
+    animationSpec = tween(durationMillis = 500, easing = NavAnimationEasing),
+    contentTransform = {
+        ContentTransform(
+            slideInHorizontally(
+                initialOffsetX = { -it / 4 },
+                animationSpec = tween(durationMillis = 550, easing = LinearEasing),
+            ),
+            slideOutHorizontally(
+                targetOffsetX = { it },
+                animationSpec = tween(durationMillis = 550, easing = LinearEasing),
+            ),
+        )
+    },
+)
 
 /** Default easing for navigation animations. */
 private val NavAnimationEasing = NavTransitionEasing(0.8f, 0.95f)


### PR DESCRIPTION
This pull request refactors how predictive back transitions are handled in the navigation UI. The main improvement is the introduction of a new `PredictivePopTransitionSpec` data class, which standardizes the configuration for predictive back gestures by encapsulating both the animation spec and the content transform. This change simplifies the API and makes it easier to customize and extend predictive back transitions. Additional improvements include more precise handling of transition progress and easing, as well as code cleanups related to predictive transition specification.

**Predictive Back Transition Refactor:**

* Introduced the `PredictivePopTransitionSpec` data class to encapsulate both the animation spec and content transform for predictive back gestures, replacing the previous function-based approach. This affects the API for specifying predictive transitions throughout `NavDisplay` and related methods. (F2634c45L117R117, F2634c45L206R206, F2634c45L290R290, F2634c45L363R363, F2634c45L796R796, F2634c45L825R825)
* Updated the default predictive pop transition to use `PredictivePopTransitionSpec`, with linear easing for slide animations and a custom easing for the overall navigation animation. (F2634c45L825R825)
* Removed the now-redundant `predictivePopSpec` method and related metadata handling, since this logic is now encapsulated in `PredictivePopTransitionSpec`. (F2634c45L796R796)

**Transition Progress and Easing Improvements:**

* Improved the calculation of transition progress during predictive back gestures by applying the correct easing and its inverse, ensuring the animation progress matches the visual state. ([miuix-navigation3-ui/src/commonMain/kotlin/androidx/navigation3/animation/NavTransitionEasing.ktR38-R57](diffhunk://#diff-430010ca82f5276fb5f7d195f0188a9a6e4be1c6c3f0745c3b21a10fd72e68b6R38-R57), F2634c45L529R529)
* Enhanced the handling of committed predictive back gestures to use the specified animation spec from the resolved `PredictivePopTransitionSpec`. (F2634c45L560R560, [miuix-navigation3-ui/src/commonMain/kotlin/androidx/navigation3/ui/NavDisplay.ktL572-R595](diffhunk://#diff-a6687d9ddd2a60dd3f9c10871bc28d5184176507a8872445884e7fd0750a0c2bL572-R595))

**API and Documentation Updates:**

* Updated function signatures, parameter names, and documentation to reflect the new `PredictivePopTransitionSpec` usage, improving clarity and consistency across the codebase. ([miuix-navigation3-ui/src/commonMain/kotlin/androidx/navigation3/ui/NavDisplay.ktL15-R16](diffhunk://#diff-a6687d9ddd2a60dd3f9c10871bc28d5184176507a8872445884e7fd0750a0c2bL15-R16), F2634c45L183R183, F2634c45L273R273, F2634c45L348R348)

These changes make the predictive back transition system more robust, customizable, and easier to maintain.