### PR TITLE
library: Remove `updateColorsFrom` text color updates

### DIFF
--- a/example/ios/iosApp/Info.plist
+++ b/example/ios/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.8</string>
 	<key>CFBundleVersion</key>
-	<string>829</string>
+	<string>832</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/theme/MiuixTheme.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/theme/MiuixTheme.kt
@@ -26,7 +26,7 @@ fun MiuixTheme(
 ) {
     val rawColors = controller.currentColors()
     val miuixColors = remember { rawColors.copy() }.apply { updateColorsFrom(rawColors) }
-    val miuixTextStyles = remember { textStyles.copy() }.apply { updateColorsFrom(miuixColors.onBackground) }
+    val miuixTextStyles = remember { textStyles.copy() }
     val miuixIndication = remember(miuixColors.onBackground) { MiuixIndication(color = miuixColors.onBackground) }
     CompositionLocalProvider(
         LocalColors provides miuixColors,
@@ -53,7 +53,7 @@ fun MiuixTheme(
     content: @Composable () -> Unit,
 ) {
     val miuixColors = remember { colors.copy() }.apply { updateColorsFrom(colors) }
-    val miuixTextStyles = remember { textStyles.copy() }.apply { updateColorsFrom(miuixColors.onBackground) }
+    val miuixTextStyles = remember { textStyles.copy() }
     val miuixIndication = remember(miuixColors.onBackground) { MiuixIndication(color = miuixColors.onBackground) }
     CompositionLocalProvider(
         LocalColors provides miuixColors,

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/theme/TextStyles.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/theme/TextStyles.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.structuralEqualityPolicy
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.em
@@ -229,22 +228,5 @@ private val Title4: TextStyle
         TextStyle(
             fontSize = 18.sp,
         )
-
-internal fun TextStyles.updateColorsFrom(color: Color) {
-    main = main.copy(color = color)
-    paragraph = paragraph.copy(color = color)
-    body1 = body1.copy(color = color)
-    body2 = body2.copy(color = color)
-    button = button.copy(color = color)
-    footnote1 = footnote1.copy(color = color)
-    footnote2 = footnote2.copy(color = color)
-    headline1 = headline1.copy(color = color)
-    headline2 = headline2.copy(color = color)
-    subtitle = subtitle.copy(color = color)
-    title1 = title1.copy(color = color)
-    title2 = title2.copy(color = color)
-    title3 = title3.copy(color = color)
-    title4 = title4.copy(color = color)
-}
 
 internal val LocalTextStyles = staticCompositionLocalOf { defaultTextStyles() }


### PR DESCRIPTION
We now have `LocalContentColor`, and the color will be set automatically.