### PR TITLE
library: add `textStyle` support to `SearchBar` `InputField`

### DIFF
--- a/docs/components/searchbar.md
+++ b/docs/components/searchbar.md
@@ -1,6 +1,8 @@
 # SearchBar
 
-`SearchBar` is a component in Miuix used for user search input. It provides an intuitive and easy-to-use search interface with support for expanded/collapsed state switching and search suggestions display.
+`SearchBar` is a component in Miuix used for user search input. It provides an intuitive and
+easy-to-use search interface with support for expanded/collapsed state switching and search
+suggestions display.
 
 <div style="position: relative; max-width: 700px; height: 250px; border-radius: 10px; overflow: hidden; border: 1px solid #777;">
     <iframe id="demoIframe" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;" src="../compose/index.html?id=searchBar" title="Demo" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin"></iframe>
@@ -43,20 +45,20 @@ SearchBar(
 
 ### SearchBar Properties
 
-| Property Name      | Type                               | Description                                       | Default Value       | Required |
-| ------------------ | ---------------------------------- | ------------------------------------------------- | ------------------- | -------- |
-| inputField         | @Composable () -> Unit             | Search input field component                      | -                   | Yes      |
-| onExpandedChange   | (Boolean) -> Unit                  | Callback when expanded state changes              | -                   | Yes      |
-| modifier           | Modifier                           | Modifier applied to the search bar                | Modifier            | No       |
-| insideMargin       | DpSize                             | Internal padding                                  | DpSize(12.dp, 0.dp) | No       |
-| expanded           | Boolean                            | Whether to show search results                    | false               | No       |
-| outsideEndAction   | @Composable (() -> Unit)?          | Action component shown on the end when expanded   | null                | No       |
-| content            | @Composable ColumnScope.() -> Unit | Content shown when expanded                       | -                   | Yes      |
+| Property Name    | Type                               | Description                                     | Default Value       | Required |
+|------------------|------------------------------------|-------------------------------------------------|---------------------|----------|
+| inputField       | @Composable () -> Unit             | Search input field component                    | -                   | Yes      |
+| onExpandedChange | (Boolean) -> Unit                  | Callback when expanded state changes            | -                   | Yes      |
+| modifier         | Modifier                           | Modifier applied to the search bar              | Modifier            | No       |
+| insideMargin     | DpSize                             | Internal padding                                | DpSize(12.dp, 0.dp) | No       |
+| expanded         | Boolean                            | Whether to show search results                  | false               | No       |
+| outsideEndAction | @Composable (() -> Unit)?          | Action component shown on the end when expanded | null                | No       |
+| content          | @Composable ColumnScope.() -> Unit | Content shown when expanded                     | -                   | Yes      |
 
 ### InputField Properties
 
 | Property Name     | Type                      | Description                          | Default Value        | Required |
-| ----------------- | ------------------------- | ------------------------------------ | -------------------- | -------- |
+|-------------------|---------------------------|--------------------------------------|----------------------|----------|
 | query             | String                    | Text content in search field         | -                    | Yes      |
 | onQueryChange     | (String) -> Unit          | Callback when text content changes   | -                    | Yes      |
 | onSearch          | (String) -> Unit          | Callback when search is executed     | -                    | Yes      |
@@ -65,6 +67,7 @@ SearchBar(
 | modifier          | Modifier                  | Modifier applied to the input field  | Modifier             | No       |
 | label             | String                    | Placeholder text when empty          | ""                   | No       |
 | enabled           | Boolean                   | Whether search field is enabled      | true                 | No       |
+| textStyle         | TextStyle                 | Style of text in search box          | null                 | Yes      |
 | leadingIcon       | @Composable (() -> Unit)? | Leading icon                         | default search icon  | No       |
 | trailingIcon      | @Composable (() -> Unit)? | Trailing icon                        | default clear button | No       |
 | interactionSource | MutableInteractionSource? | Interaction source                   | null                 | No       |

--- a/docs/zh_CN/components/searchbar.md
+++ b/docs/zh_CN/components/searchbar.md
@@ -43,31 +43,32 @@ SearchBar(
 
 ### SearchBar 属性
 
-| 属性名             | 类型                               | 说明                       | 默认值              | 是否必须 |
-| ------------------ | ---------------------------------- | -------------------------- | ------------------- | -------- |
-| inputField         | @Composable () -> Unit             | 搜索输入框组件             | -                   | 是       |
-| onExpandedChange   | (Boolean) -> Unit                  | 展开状态变化的回调         | -                   | 是       |
-| modifier           | Modifier                           | 应用于搜索栏的修饰符       | Modifier            | 否       |
-| insideMargin       | DpSize                             | 内部边距                   | DpSize(12.dp, 0.dp) | 否       |
-| expanded           | Boolean                            | 是否展开显示搜索结果       | false               | 否       |
-| outsideEndAction.  | @Composable (() -> Unit)?          | 展开时显示在右侧的操作组件 | null                | 否       |
-| content            | @Composable ColumnScope.() -> Unit | 展开时显示的内容           | -                   | 是       |
+| 属性名               | 类型                                 | 说明            | 默认值                 | 是否必须 |
+|-------------------|------------------------------------|---------------|---------------------|------|
+| inputField        | @Composable () -> Unit             | 搜索输入框组件       | -                   | 是    |
+| onExpandedChange  | (Boolean) -> Unit                  | 展开状态变化的回调     | -                   | 是    |
+| modifier          | Modifier                           | 应用于搜索栏的修饰符    | Modifier            | 否    |
+| insideMargin      | DpSize                             | 内部边距          | DpSize(12.dp, 0.dp) | 否    |
+| expanded          | Boolean                            | 是否展开显示搜索结果    | false               | 否    |
+| outsideEndAction. | @Composable (() -> Unit)?          | 展开时显示在右侧的操作组件 | null                | 否    |
+| content           | @Composable ColumnScope.() -> Unit | 展开时显示的内容      | -                   | 是    |
 
 ### InputField 属性
 
-| 属性名            | 类型                      | 说明                       | 默认值       | 是否必须 |
-| ----------------- | ------------------------- | -------------------------- | ------------ | -------- |
-| query             | String                    | 搜索框中的文本内容         | -            | 是       |
-| onQueryChange     | (String) -> Unit          | 文本内容变化时的回调       | -            | 是       |
-| onSearch          | (String) -> Unit          | 执行搜索操作时的回调       | -            | 是       |
-| expanded          | Boolean                   | 是否处于展开状态           | -            | 是       |
-| onExpandedChange  | (Boolean) -> Unit         | 展开状态变化的回调         | -            | 是       |
-| modifier          | Modifier                  | 应用于输入框的修饰符       | Modifier     | 否       |
-| label             | String                    | 搜索框为空时显示的提示文本 | ""           | 否       |
-| enabled           | Boolean                   | 是否启用搜索框             | true         | 否       |
-| leadingIcon       | @Composable (() -> Unit)? | 前置图标                   | 默认放大镜   | 否       |
-| trailingIcon      | @Composable (() -> Unit)? | 后置图标                   | 默认清除按钮 | 否       |
-| interactionSource | MutableInteractionSource? | 交互源                     | null         | 否       |
+| 属性名               | 类型                        | 说明            | 默认值      | 是否必须 |
+|-------------------|---------------------------|---------------|----------|------|
+| query             | String                    | 搜索框中的文本内容     | -        | 是    |
+| onQueryChange     | (String) -> Unit          | 文本内容变化时的回调    | -        | 是    |
+| onSearch          | (String) -> Unit          | 执行搜索操作时的回调    | -        | 是    |
+| expanded          | Boolean                   | 是否处于展开状态      | -        | 是    |
+| onExpandedChange  | (Boolean) -> Unit         | 展开状态变化的回调     | -        | 是    |
+| modifier          | Modifier                  | 应用于输入框的修饰符    | Modifier | 否    |
+| label             | String                    | 搜索框为空时显示的提示文本 | ""       | 否    |
+| enabled           | Boolean                   | 是否启用搜索框       | true     | 否    |
+| textStyle         | TextStyle                 | 搜索框中文本的样式     | null     | 否    |
+| leadingIcon       | @Composable (() -> Unit)? | 前置图标          | 默认放大镜    | 否    |
+| trailingIcon      | @Composable (() -> Unit)? | 后置图标          | 默认清除按钮   | 否    |
+| interactionSource | MutableInteractionSource? | 交互源           | null     | 否    |
 
 ## 进阶用法
 

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/SearchBar.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/SearchBar.kt
@@ -144,6 +144,7 @@ fun SearchBar(
  *   emitting [Interaction]s for this input field. You can use this to change the search bar's
  *   appearance or preview the search bar in different states. Note that if `null` is provided,
  *   interactions will still happen internally.
+ * @param textStyle Style configuration that applies at character level such as color, font etc.
  */
 @Composable
 fun InputField(
@@ -155,6 +156,7 @@ fun InputField(
     modifier: Modifier = Modifier,
     label: String = "",
     enabled: Boolean = true,
+    textStyle: TextStyle? = null,
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
     interactionSource: MutableInteractionSource? = null,
@@ -200,7 +202,10 @@ fun InputField(
     val focusManager = LocalFocusManager.current
 
     val textColor = LocalContentColor.current
-    val inputTextStyle = MiuixTheme.textStyles.main.copy(fontWeight = FontWeight.Bold, color = textColor)
+    val inputTextStyle = MiuixTheme.textStyles.main
+        .copy(fontWeight = FontWeight.Bold)
+        .merge(textStyle)
+        .copy(color = textColor)
 
     val cursorBrush = SolidColor(MiuixTheme.colorScheme.primary)
     val labelText by remember(query, expanded, label) {
@@ -248,7 +253,7 @@ fun InputField(
                     ) {
                         Text(
                             text = labelText,
-                            style = TextStyle(fontSize = 17.sp, fontWeight = FontWeight.Bold),
+                            style = TextStyle(fontSize = 17.sp, fontWeight = FontWeight.Bold).merge(textStyle),
                             color = MiuixTheme.colorScheme.onSurfaceContainerHigh,
                         )
                         innerTextField()

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/SearchBar.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/SearchBar.kt
@@ -138,13 +138,13 @@ fun SearchBar(
  * @param enabled the enabled state of this input field. When `false`, this component will not
  *   respond to user input, and it will appear visually disabled and disabled to accessibility
  *   services.
+ * @param textStyle Style configuration that applies at character level such as color, font etc.
  * @param leadingIcon the leading icon to be displayed at the start of the input field.
  * @param trailingIcon the trailing icon to be displayed at the end of the input field.
  * @param interactionSource an optional hoisted [MutableInteractionSource] for observing and
  *   emitting [Interaction]s for this input field. You can use this to change the search bar's
  *   appearance or preview the search bar in different states. Note that if `null` is provided,
  *   interactions will still happen internally.
- * @param textStyle Style configuration that applies at character level such as color, font etc.
  */
 @Composable
 fun InputField(


### PR DESCRIPTION
- Added `textStyle` parameter to `InputField` to allow character-level styling.
- Merged the provided `textStyle` into the internal `inputTextStyle` and placeholder `Text` style.
- Updated documentation for `SearchBar` in both English and Chinese to include the new `textStyle` property.
- Improved table formatting in documentation files.