### PR TITLE
library: optimize recomposition and performance for UI components

### DIFF
--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Icon.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Icon.kt
@@ -6,11 +6,7 @@ package top.yukonga.miuix.kmp.basic
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.NonRestartableComposable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.draw.paint
@@ -46,7 +42,6 @@ import top.yukonga.miuix.kmp.theme.LocalContentColor
  *   is applied.
  */
 @Composable
-@NonRestartableComposable
 fun Icon(
     imageVector: ImageVector,
     contentDescription: String?,
@@ -74,7 +69,6 @@ fun Icon(
  *   applied.
  */
 @Composable
-@NonRestartableComposable
 fun Icon(
     bitmap: ImageBitmap,
     contentDescription: String?,
@@ -103,34 +97,29 @@ fun Icon(
  *   applied.
  */
 @Composable
-@NonRestartableComposable
 fun Icon(
     painter: Painter,
     contentDescription: String?,
     modifier: Modifier = Modifier,
     tint: Color = LocalContentColor.current,
 ) {
-    val colorFilter by remember(tint) {
-        derivedStateOf { if (tint == Color.Unspecified) null else ColorFilter.tint(tint) }
-    }
-    val semanticsModifier by remember(contentDescription) {
-        derivedStateOf {
-            if (contentDescription != null) {
-                Modifier.semantics {
-                    this.contentDescription = contentDescription
-                    this.role = Role.Image
-                }
-            } else {
-                Modifier
+    val colorFilter =
+        remember(tint) { if (tint == Color.Unspecified) null else ColorFilter.tint(tint) }
+    val semantics =
+        if (contentDescription != null) {
+            Modifier.semantics {
+                this.contentDescription = contentDescription
+                this.role = Role.Image
             }
+        } else {
+            Modifier
         }
-    }
     Box(
         modifier
             .toolingGraphicsLayer()
             .defaultSizeFor(painter)
             .paint(painter, colorFilter = colorFilter, contentScale = ContentScale.Fit)
-            .then(semanticsModifier),
+            .then(semantics),
     )
 }
 
@@ -146,14 +135,12 @@ fun Icon(
  * @param modifier the [Modifier] to be applied to this icon
  */
 @Composable
-@NonRestartableComposable
 fun Icon(
     painter: Painter,
     tint: ColorProducer?,
     contentDescription: String?,
     modifier: Modifier = Modifier,
 ) {
-    val currentTint by rememberUpdatedState(tint)
     Icon(
         painter = painter,
         tint = Color.Unspecified,
@@ -163,7 +150,7 @@ fun Icon(
             val layer = obtainGraphicsLayer()
             layer.apply {
                 record { drawContent() }
-                currentTint?.let { this@apply.colorFilter = ColorFilter.tint(it()) }
+                tint?.let { this@apply.colorFilter = ColorFilter.tint(it()) }
             }
             onDrawWithContent { drawLayer(graphicsLayer = layer) }
         },

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/IconButton.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/IconButton.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -41,7 +40,6 @@ import top.yukonga.miuix.kmp.interfaces.HoldDownInteraction
  * @param content The content of this icon button, typically an [Icon].
  */
 @Composable
-@NonRestartableComposable
 fun IconButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/ProgressIndicator.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/ProgressIndicator.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -26,6 +25,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -43,16 +43,16 @@ import kotlin.math.sin
  * @param height The height of the indicator.
  */
 @Composable
-@NonRestartableComposable
 fun LinearProgressIndicator(
     modifier: Modifier = Modifier,
     progress: Float? = null,
     colors: ProgressIndicatorColors = ProgressIndicatorDefaults.progressIndicatorColors(),
     height: Dp = ProgressIndicatorDefaults.DefaultLinearProgressIndicatorHeight,
 ) {
+    val currentBackgroundColor = colors.backgroundColor()
+    val currentForegroundColor = colors.foregroundColor(true)
+
     if (progress == null) {
-        val currentBackgroundColor = colors.backgroundColor()
-        val currentForegroundColor = colors.foregroundColor(true)
         val transition = rememberInfiniteTransition()
         val animatedValue by transition.animateFloat(
             initialValue = 0f,
@@ -70,113 +70,16 @@ fun LinearProgressIndicator(
         ) {
             drawRoundRect(
                 color = currentBackgroundColor,
-                size = Size(size.width, size.height),
+                size = size,
                 cornerRadius = CornerRadius(size.height / 2),
             )
 
-            val value = animatedValue
-            val segmentWidth = 0.45f
-            val gap = 0.55f
-            run {
-                val adjustedPos = (value % 1f + 1f) % 1f
-                if (adjustedPos < 1f - segmentWidth) {
-                    val startX = size.width * adjustedPos
-                    val width = size.width * segmentWidth
-                    drawRoundRect(
-                        color = currentForegroundColor,
-                        topLeft = Offset(startX, 0f),
-                        size = Size(width, size.height),
-                        cornerRadius = CornerRadius(size.height / 2),
-                    )
-                } else {
-                    val startX = size.width * adjustedPos
-                    val width = size.width * (1f - adjustedPos)
-                    drawRoundRect(
-                        color = currentForegroundColor,
-                        topLeft = Offset(startX, 0f),
-                        size = Size(width, size.height),
-                        cornerRadius = CornerRadius(size.height / 2),
-                    )
-                    val remainingWidth = adjustedPos + segmentWidth - 1f
-                    if (remainingWidth > 0) {
-                        drawRoundRect(
-                            color = currentForegroundColor,
-                            topLeft = Offset(0f, 0f),
-                            size = Size(size.width * remainingWidth, size.height),
-                            cornerRadius = CornerRadius(size.height / 2),
-                        )
-                    }
-                }
-            }
-            run {
-                val position = value - (segmentWidth + gap)
-                val adjustedPos = (position % 1f + 1f) % 1f
-                if (adjustedPos < 1f - segmentWidth) {
-                    val startX = size.width * adjustedPos
-                    val width = size.width * segmentWidth
-                    drawRoundRect(
-                        color = currentForegroundColor,
-                        topLeft = Offset(startX, 0f),
-                        size = Size(width, size.height),
-                        cornerRadius = CornerRadius(size.height / 2),
-                    )
-                } else {
-                    val startX = size.width * adjustedPos
-                    val width = size.width * (1f - adjustedPos)
-                    drawRoundRect(
-                        color = currentForegroundColor,
-                        topLeft = Offset(startX, 0f),
-                        size = Size(width, size.height),
-                        cornerRadius = CornerRadius(size.height / 2),
-                    )
-                    val remainingWidth = adjustedPos + segmentWidth - 1f
-                    if (remainingWidth > 0) {
-                        drawRoundRect(
-                            color = currentForegroundColor,
-                            topLeft = Offset(0f, 0f),
-                            size = Size(size.width * remainingWidth, size.height),
-                            cornerRadius = CornerRadius(size.height / 2),
-                        )
-                    }
-                }
-            }
-            run {
-                val position = value - 2 * (segmentWidth + gap)
-                val adjustedPos = (position % 1f + 1f) % 1f
-                if (adjustedPos < 1f - segmentWidth) {
-                    val startX = size.width * adjustedPos
-                    val width = size.width * segmentWidth
-                    drawRoundRect(
-                        color = currentForegroundColor,
-                        topLeft = Offset(startX, 0f),
-                        size = Size(width, size.height),
-                        cornerRadius = CornerRadius(size.height / 2),
-                    )
-                } else {
-                    val startX = size.width * adjustedPos
-                    val width = size.width * (1f - adjustedPos)
-                    drawRoundRect(
-                        color = currentForegroundColor,
-                        topLeft = Offset(startX, 0f),
-                        size = Size(width, size.height),
-                        cornerRadius = CornerRadius(size.height / 2),
-                    )
-                    val remainingWidth = adjustedPos + segmentWidth - 1f
-                    if (remainingWidth > 0) {
-                        drawRoundRect(
-                            color = currentForegroundColor,
-                            topLeft = Offset(0f, 0f),
-                            size = Size(size.width * remainingWidth, size.height),
-                            cornerRadius = CornerRadius(size.height / 2),
-                        )
-                    }
-                }
+            for (i in 0 until 3) {
+                drawIndeterminateSegment(animatedValue, i, currentForegroundColor)
             }
         }
     } else {
         val progressValue = progress.coerceIn(0f, 1f)
-        val currentBackgroundColor = colors.backgroundColor()
-        val currentForegroundColor = colors.foregroundColor(true)
 
         Canvas(
             modifier = modifier
@@ -187,7 +90,7 @@ fun LinearProgressIndicator(
 
             drawRoundRect(
                 color = currentBackgroundColor,
-                size = Size(size.width, size.height),
+                size = size,
                 cornerRadius = CornerRadius(cornerRadius),
             )
 
@@ -196,7 +99,6 @@ fun LinearProgressIndicator(
 
             drawRoundRect(
                 color = currentForegroundColor,
-                topLeft = Offset(0f, 0f),
                 size = Size(progressWidth, size.height),
                 cornerRadius = CornerRadius(cornerRadius),
             )
@@ -214,7 +116,6 @@ fun LinearProgressIndicator(
  * @param size The size (diameter) of the circular indicator.
  */
 @Composable
-@NonRestartableComposable
 fun CircularProgressIndicator(
     modifier: Modifier = Modifier,
     progress: Float? = null,
@@ -222,9 +123,10 @@ fun CircularProgressIndicator(
     strokeWidth: Dp = ProgressIndicatorDefaults.DefaultCircularProgressIndicatorStrokeWidth,
     size: Dp = ProgressIndicatorDefaults.DefaultCircularProgressIndicatorSize,
 ) {
+    val currentBackgroundColor = colors.backgroundColor()
+    val currentForegroundColor = colors.foregroundColor(true)
+
     if (progress == null) {
-        val currentBackgroundColor = colors.backgroundColor()
-        val currentForegroundColor = colors.foregroundColor(true)
         val transition = rememberInfiniteTransition()
 
         val rotationAnim by transition.animateFloat(
@@ -255,12 +157,7 @@ fun CircularProgressIndicator(
             val radius = (size.toPx() - strokeWidthPx) / 2
             val center = Offset(size.toPx() / 2, size.toPx() / 2)
 
-            drawCircle(
-                color = currentBackgroundColor,
-                radius = radius,
-                center = center,
-                style = Stroke(width = strokeWidthPx),
-            )
+            drawCircularBackground(currentBackgroundColor, radius, center, strokeWidthPx)
 
             drawArc(
                 color = currentForegroundColor,
@@ -274,8 +171,6 @@ fun CircularProgressIndicator(
         }
     } else {
         val progressValue = progress.coerceIn(0f, 1f)
-        val currentBackgroundColor = colors.backgroundColor()
-        val currentForegroundColor = colors.foregroundColor(true)
 
         Canvas(
             modifier = modifier.size(size),
@@ -284,12 +179,7 @@ fun CircularProgressIndicator(
             val radius = (size.toPx() - strokeWidthPx) / 2
             val center = Offset(size.toPx() / 2, size.toPx() / 2)
 
-            drawCircle(
-                color = currentBackgroundColor,
-                radius = radius,
-                center = center,
-                style = Stroke(width = strokeWidthPx),
-            )
+            drawCircularBackground(currentBackgroundColor, radius, center, strokeWidthPx)
 
             val minSweepAngle = 0.1f
             val sweepAngle = minSweepAngle + (360f - minSweepAngle) * progressValue
@@ -318,7 +208,6 @@ fun CircularProgressIndicator(
  * @param orbitingDotSize The size of the orbiting dot.
  */
 @Composable
-@NonRestartableComposable
 fun InfiniteProgressIndicator(
     modifier: Modifier = Modifier,
     color: Color = Color.Gray,
@@ -339,18 +228,20 @@ fun InfiniteProgressIndicator(
     Canvas(
         modifier = modifier.size(size),
     ) {
+        val strokeWidthPx = strokeWidth.toPx()
+        val orbitingDotSizePx = orbitingDotSize.toPx()
         val center = Offset(this.size.width / 2, this.size.height / 2)
-        val radius = (size.toPx() - strokeWidth.toPx()) / 2
+        val radius = (size.toPx() - strokeWidthPx) / 2
 
         drawCircle(
             color = color,
             radius = radius,
             center = center,
-            style = Stroke(strokeWidth.toPx(), cap = StrokeCap.Round),
+            style = Stroke(strokeWidthPx, cap = StrokeCap.Round),
         )
 
-        val orbitRadius = radius - 2 * orbitingDotSize.toPx()
-        val angle = rotation * PI.toFloat() / 180f
+        val orbitRadius = radius - 2 * orbitingDotSizePx
+        val angle = rotation * (PI / 180.0).toFloat()
         val dotCenter = center + Offset(
             x = orbitRadius * cos(angle),
             y = orbitRadius * sin(angle),
@@ -358,10 +249,64 @@ fun InfiniteProgressIndicator(
 
         drawCircle(
             color = color,
-            radius = orbitingDotSize.toPx(),
+            radius = orbitingDotSizePx,
             center = dotCenter,
         )
     }
+}
+
+/**
+ * Draws a single animated segment for the indeterminate linear progress indicator.
+ */
+private fun DrawScope.drawIndeterminateSegment(
+    animatedValue: Float,
+    segmentIndex: Int,
+    color: Color,
+) {
+    val position = animatedValue - segmentIndex * (0.45f + 0.55f)
+    val adjustedPos = (position % 1f + 1f) % 1f
+    val cornerRadius = CornerRadius(size.height / 2)
+
+    if (adjustedPos < 1f - 0.45f) {
+        drawRoundRect(
+            color = color,
+            topLeft = Offset(size.width * adjustedPos, 0f),
+            size = Size(size.width * 0.45f, size.height),
+            cornerRadius = cornerRadius,
+        )
+    } else {
+        drawRoundRect(
+            color = color,
+            topLeft = Offset(size.width * adjustedPos, 0f),
+            size = Size(size.width * (1f - adjustedPos), size.height),
+            cornerRadius = cornerRadius,
+        )
+        val remainingWidth = adjustedPos + 0.45f - 1f
+        if (remainingWidth > 0) {
+            drawRoundRect(
+                color = color,
+                size = Size(size.width * remainingWidth, size.height),
+                cornerRadius = cornerRadius,
+            )
+        }
+    }
+}
+
+/**
+ * Draws a circular background ring used by [CircularProgressIndicator].
+ */
+private fun DrawScope.drawCircularBackground(
+    color: Color,
+    radius: Float,
+    center: Offset,
+    strokeWidthPx: Float,
+) {
+    drawCircle(
+        color = color,
+        radius = radius,
+        center = center,
+        style = Stroke(width = strokeWidthPx),
+    )
 }
 
 object ProgressIndicatorDefaults {

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/PullToRefresh.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/PullToRefresh.kt
@@ -139,16 +139,18 @@ fun PullToRefresh(
         }
 
     // A modifier to detect when the user releases their finger and trigger the refresh logic.
-    val pointerModifier = Modifier.pointerInput(Unit) {
-        awaitPointerEventScope {
-            while (true) {
-                val event = awaitPointerEvent()
-                if (
-                    (pullToRefreshState.refreshState == RefreshState.Pulling || pullToRefreshState.refreshState == RefreshState.ThresholdReached) &&
-                    event.changes.all { !it.pressed }
-                ) {
-                    coroutineScope.launch {
-                        pullToRefreshState.handlePointerRelease(currentOnRefresh)
+    val pointerModifier = remember(pullToRefreshState) {
+        Modifier.pointerInput(Unit) {
+            awaitPointerEventScope {
+                while (true) {
+                    val event = awaitPointerEvent()
+                    if (
+                        (pullToRefreshState.refreshState == RefreshState.Pulling || pullToRefreshState.refreshState == RefreshState.ThresholdReached) &&
+                        event.changes.all { !it.pressed }
+                    ) {
+                        coroutineScope.launch {
+                            pullToRefreshState.handlePointerRelease(currentOnRefresh)
+                        }
                     }
                 }
             }
@@ -158,9 +160,11 @@ fun PullToRefresh(
     CompositionLocalProvider(
         LocalPullToRefreshState provides pullToRefreshState,
     ) {
-        val boxModifier = modifier
-            .nestedScroll(nestedScrollConnection)
-            .then(pointerModifier)
+        val boxModifier = remember(modifier, nestedScrollConnection, pointerModifier) {
+            modifier
+                .nestedScroll(nestedScrollConnection)
+                .then(pointerModifier)
+        }
 
         Box(modifier = boxModifier) {
             Column {
@@ -368,10 +372,7 @@ class PullToRefreshState(
         val animatedValue = Animatable(0f)
         animatedValue.animateTo(
             targetValue = 1f,
-            animationSpec = tween(
-                durationMillis = 200,
-                easing = CubicBezierEasing(0f, 0f, 0f, 0.37f),
-            ),
+            animationSpec = tween<Float>(durationMillis = 200, easing = CubicBezierEasing(0f, 0f, 0f, 0.37f)),
         ) {
             refreshCompleteAnimProgressState.floatValue = this.value
         }
@@ -548,7 +549,7 @@ private fun RefreshHeader(
         }
     }
 
-    val refreshDisplayInfo by remember(pullToRefreshState) {
+    val refreshDisplayInfo by remember(pullToRefreshState, refreshTexts) {
         derivedStateOf {
             when (pullToRefreshState.refreshState) {
                 RefreshState.Idle -> "" to 0f
@@ -573,7 +574,7 @@ private fun RefreshHeader(
         }
     }
 
-    val heightInfo by remember(pullToRefreshState) {
+    val heightInfo by remember(pullToRefreshState, circleSize, density) {
         derivedStateOf {
             val dragOffset = pullToRefreshState.dragOffset
             val threshold = pullToRefreshState.refreshThresholdOffset
@@ -644,12 +645,11 @@ private fun RefreshIndicator(
         contentAlignment = Alignment.TopCenter,
     ) {
         // Only create rotation animation when actually refreshing to save resources
-        val rotation = if (pullToRefreshState.refreshState == RefreshState.Refreshing) {
+        val rotationState = if (pullToRefreshState.refreshState == RefreshState.Refreshing) {
             animateRotation()
         } else {
-            remember { mutableFloatStateOf(0f) }
+            null
         }
-        val rotationValue by rotation
         Canvas(modifier = Modifier.size(circleSize)) {
             val ringStrokeWidthPx = circleSize.toPx() / 11
             val indicatorRadiusPx = max(size.minDimension / 2, circleSize.toPx() / 3.5f)
@@ -681,7 +681,7 @@ private fun RefreshIndicator(
                         indicatorRadiusPx,
                         ringStrokeWidthPx,
                         color,
-                        rotationValue,
+                        rotationState?.value ?: 0f,
                     )
                 }
 
@@ -706,7 +706,7 @@ private fun animateRotation(): State<Float> {
     return infiniteTransition.animateFloat(
         initialValue = initialRotation,
         targetValue = initialRotation + 360f,
-        animationSpec = infiniteRepeatable(
+        animationSpec = infiniteRepeatable<Float>(
             animation = tween(800, easing = LinearEasing),
             repeatMode = RepeatMode.Restart,
         ),

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Slider.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Slider.kt
@@ -23,8 +23,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -86,7 +86,6 @@ import kotlin.math.abs
  *   distance from a key point, it will snap to that point. Default is 0.02 (2%). Only applies when [keyPoints] is set.
  */
 @Composable
-@NonRestartableComposable
 fun Slider(
     value: Float,
     onValueChange: (Float) -> Unit,
@@ -123,16 +122,17 @@ fun Slider(
 
     val coercedValue = value.coerceIn(valueRange.start, valueRange.endInclusive)
 
-    val progressAnimationSpec = if (isDragging) {
-        spring<Float>(dampingRatio = 0.9f, stiffness = 1755f)
-    } else {
-        spring<Float>(dampingRatio = 0.96f, stiffness = 322f)
+    val progressAnimationSpec = remember(isDragging) {
+        if (isDragging) {
+            spring(dampingRatio = 0.9f, stiffness = 1755f)
+        } else {
+            spring<Float>(dampingRatio = 0.96f, stiffness = 322f)
+        }
     }
-    val thumbScaleAnimationSpec = spring<Float>(dampingRatio = 0.6f, stiffness = 987f)
 
     val animatedValueState = animateFloatAsState(coercedValue, progressAnimationSpec)
     val animatedValue by animatedValueState
-    val thumbScale by animateFloatAsState(if (isPressed || isDragging || isHoveringThumb) 1.127f else 1f, thumbScaleAnimationSpec)
+    val thumbScale by animateFloatAsState(if (isPressed || isDragging || isHoveringThumb) 1.127f else 1f, ThumbScaleAnimationSpec)
 
     val stepFractions = remember(steps) { stepsToTickFractions(steps) }
 
@@ -157,6 +157,9 @@ fun Slider(
         }
     }
 
+    val currentLayoutWidth by rememberUpdatedState(layoutWidth)
+    val currentLayoutHeight by rememberUpdatedState(layoutHeight)
+
     Box(
         modifier = modifier
             .then(
@@ -166,12 +169,7 @@ fun Slider(
                             layoutWidth = it.width
                             layoutHeight = it.height
                         }
-                        .pointerInput(layoutWidth, layoutHeight, effectiveReverseDirection, valueRange) {
-                            val thumbRadius = layoutHeight / 2f
-                            val availableWidth = (layoutWidth - 2f * thumbRadius).coerceAtLeast(0f)
-                            val knobRadius = thumbRadius * 0.72f
-                            val hitRadius = knobRadius + (thumbRadius * 0.5f)
-
+                        .pointerInput(effectiveReverseDirection, valueRange) {
                             awaitPointerEventScope {
                                 while (true) {
                                     val event = awaitPointerEvent()
@@ -184,6 +182,11 @@ fun Slider(
                                         isHoveringThumb = false
                                         continue
                                     }
+
+                                    val thumbRadius = currentLayoutHeight / 2f
+                                    val availableWidth = (currentLayoutWidth - 2f * thumbRadius).coerceAtLeast(0f)
+                                    val knobRadius = thumbRadius * 0.72f
+                                    val hitRadius = knobRadius + (thumbRadius * 0.5f)
 
                                     val position = change.position
                                     val fraction = (animatedValueState.value - valueRange.start) / (valueRange.endInclusive - valueRange.start)
@@ -292,7 +295,6 @@ fun Slider(
  *   Values should be within [valueRange].
  */
 @Composable
-@NonRestartableComposable
 fun VerticalSlider(
     value: Float,
     onValueChange: (Float) -> Unit,
@@ -328,16 +330,17 @@ fun VerticalSlider(
 
     val coercedValue = value.coerceIn(valueRange.start, valueRange.endInclusive)
 
-    val progressAnimationSpec = if (isDragging) {
-        spring<Float>(dampingRatio = 0.9f, stiffness = 1755f)
-    } else {
-        spring<Float>(dampingRatio = 0.96f, stiffness = 322f)
+    val progressAnimationSpec = remember(isDragging) {
+        if (isDragging) {
+            spring(dampingRatio = 0.9f, stiffness = 1755f)
+        } else {
+            spring<Float>(dampingRatio = 0.96f, stiffness = 322f)
+        }
     }
-    val thumbScaleAnimationSpec = spring<Float>(dampingRatio = 0.6f, stiffness = 987f)
 
     val animatedValueState = animateFloatAsState(coercedValue, progressAnimationSpec)
     val animatedValue by animatedValueState
-    val thumbScale by animateFloatAsState(if (isPressed || isDragging || isHoveringThumb) 1.127f else 1f, thumbScaleAnimationSpec)
+    val thumbScale by animateFloatAsState(if (isPressed || isDragging || isHoveringThumb) 1.127f else 1f, ThumbScaleAnimationSpec)
 
     val stepFractions = remember(steps) { stepsToTickFractions(steps) }
 
@@ -362,6 +365,9 @@ fun VerticalSlider(
         }
     }
 
+    val currentLayoutWidth by rememberUpdatedState(layoutWidth)
+    val currentLayoutHeight by rememberUpdatedState(layoutHeight)
+
     Box(
         modifier = modifier
             .then(
@@ -371,12 +377,7 @@ fun VerticalSlider(
                             layoutWidth = it.width
                             layoutHeight = it.height
                         }
-                        .pointerInput(layoutWidth, layoutHeight, reverseDirection, valueRange) {
-                            val thumbRadius = layoutWidth / 2f
-                            val availableHeight = (layoutHeight - 2f * thumbRadius).coerceAtLeast(0f)
-                            val knobRadius = thumbRadius * 0.72f
-                            val hitRadius = knobRadius + (thumbRadius * 0.5f)
-
+                        .pointerInput(reverseDirection, valueRange) {
                             awaitPointerEventScope {
                                 while (true) {
                                     val event = awaitPointerEvent()
@@ -389,6 +390,11 @@ fun VerticalSlider(
                                         isHoveringThumb = false
                                         continue
                                     }
+
+                                    val thumbRadius = currentLayoutWidth / 2f
+                                    val availableHeight = (currentLayoutHeight - 2f * thumbRadius).coerceAtLeast(0f)
+                                    val knobRadius = thumbRadius * 0.72f
+                                    val hitRadius = knobRadius + (thumbRadius * 0.5f)
 
                                     val position = change.position
                                     val fraction =
@@ -496,7 +502,6 @@ fun VerticalSlider(
  *   distance from a key point, it will snap to that point. Default is 0.02 (2%). Only applies when [keyPoints] is set.
  */
 @Composable
-@NonRestartableComposable
 fun RangeSlider(
     value: ClosedFloatingPointRange<Float>,
     onValueChange: (ClosedFloatingPointRange<Float>) -> Unit,
@@ -526,7 +531,7 @@ fun RangeSlider(
     var isDraggingEnd by remember { mutableStateOf(false) }
     var isHoveringStartThumb by remember { mutableStateOf(false) }
     var isHoveringEndThumb by remember { mutableStateOf(false) }
-    val isDragging = isDraggingStart || isDraggingEnd
+    val isDragging by remember { derivedStateOf { isDraggingStart || isDraggingEnd } }
     val hapticState = remember { RangeSliderHapticState() }
     val interactionSource = remember { MutableInteractionSource() }
     val shape = remember(height) { RoundedRectangle(height) }
@@ -546,12 +551,13 @@ fun RangeSlider(
     val coercedStart = currentStartValue.coerceIn(valueRange.start, valueRange.endInclusive)
     val coercedEnd = currentEndValue.coerceIn(valueRange.start, valueRange.endInclusive)
 
-    val progressAnimationSpec = if (isDragging) {
-        spring<Float>(dampingRatio = 0.9f, stiffness = 1755f)
-    } else {
-        spring<Float>(dampingRatio = 0.96f, stiffness = 322f)
+    val progressAnimationSpec = remember(isDragging) {
+        if (isDragging) {
+            spring(dampingRatio = 0.9f, stiffness = 1755f)
+        } else {
+            spring<Float>(dampingRatio = 0.96f, stiffness = 322f)
+        }
     }
-    val thumbScaleAnimationSpec = spring<Float>(dampingRatio = 0.6f, stiffness = 987f)
 
     val animatedStartValueState = animateFloatAsState(coercedStart, progressAnimationSpec)
     val animatedEndValueState = animateFloatAsState(coercedEnd, progressAnimationSpec)
@@ -559,9 +565,9 @@ fun RangeSlider(
     val animatedEndValue by animatedEndValueState
     val startThumbScale by animateFloatAsState(
         if (isDraggingStart || isPressed || isHoveringStartThumb) 1.127f else 1f,
-        thumbScaleAnimationSpec,
+        ThumbScaleAnimationSpec,
     )
-    val endThumbScale by animateFloatAsState(if (isDraggingEnd || isPressed || isHoveringEndThumb) 1.127f else 1f, thumbScaleAnimationSpec)
+    val endThumbScale by animateFloatAsState(if (isDraggingEnd || isPressed || isHoveringEndThumb) 1.127f else 1f, ThumbScaleAnimationSpec)
 
     val stepFractions = remember(steps) { stepsToTickFractions(steps) }
 
@@ -586,6 +592,9 @@ fun RangeSlider(
         }
     }
 
+    val currentLayoutWidth by rememberUpdatedState(layoutWidth)
+    val currentLayoutHeight by rememberUpdatedState(layoutHeight)
+
     Box(
         modifier = modifier
             .then(
@@ -595,12 +604,7 @@ fun RangeSlider(
                             layoutWidth = it.width
                             layoutHeight = it.height
                         }
-                        .pointerInput(layoutWidth, layoutHeight, isRtl, valueRange) {
-                            val thumbRadius = layoutHeight / 2f
-                            val availableWidth = (layoutWidth - 2f * thumbRadius).coerceAtLeast(0f)
-                            val knobRadius = thumbRadius * 0.72f
-                            val hitRadius = knobRadius + (thumbRadius * 0.5f)
-
+                        .pointerInput(isRtl, valueRange) {
                             awaitPointerEventScope {
                                 while (true) {
                                     val event = awaitPointerEvent()
@@ -614,6 +618,11 @@ fun RangeSlider(
                                         isHoveringEndThumb = false
                                         continue
                                     }
+
+                                    val thumbRadius = currentLayoutHeight / 2f
+                                    val availableWidth = (currentLayoutWidth - 2f * thumbRadius).coerceAtLeast(0f)
+                                    val knobRadius = thumbRadius * 0.72f
+                                    val hitRadius = knobRadius + (thumbRadius * 0.5f)
 
                                     val position = change.position
                                     val startFraction = (animatedStartValueState.value - valueRange.start) / (valueRange.endInclusive - valueRange.start)
@@ -1294,6 +1303,8 @@ private fun resolveValueFromFraction(
         else -> base
     }
 }
+
+private val ThumbScaleAnimationSpec = spring<Float>(dampingRatio = 0.6f, stiffness = 987f)
 
 private fun horizontalVisualFraction(offsetX: Float, sizeWidth: Int, sizeHeight: Int): Float {
     val thumbRadius = sizeHeight / 2f

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Surface.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Surface.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -44,7 +43,6 @@ import top.yukonga.miuix.kmp.theme.MiuixTheme
  * @param content The [Composable] content of the [Surface].
  */
 @Composable
-@NonRestartableComposable
 fun Surface(
     modifier: Modifier = Modifier,
     shape: Shape = RectangleShape,
@@ -93,7 +91,6 @@ fun Surface(
  * @param content The [Composable] content of the [Surface].
  */
 @Composable
-@NonRestartableComposable
 fun Surface(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/TabRow.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/TabRow.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -64,7 +63,6 @@ import kotlin.math.roundToInt
  * @param contentAlignment The content alignment of the tab in [TabRow].
  */
 @Composable
-@NonRestartableComposable
 fun TabRow(
     tabs: List<String>,
     selectedTabIndex: Int,
@@ -163,7 +161,6 @@ fun TabRow(
  * @param contentAlignment The content alignment of the tab in [TabRow].
  */
 @Composable
-@NonRestartableComposable
 fun TabRowWithContour(
     tabs: List<String>,
     selectedTabIndex: Int,

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/TextField.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/TextField.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.text.input.TextFieldDecorator
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -80,7 +79,6 @@ import top.yukonga.miuix.kmp.theme.MiuixTheme
  * @param scrollState The scroll state for the text field.
  */
 @Composable
-@NonRestartableComposable
 fun TextField(
     state: TextFieldState,
     modifier: Modifier = Modifier,
@@ -112,8 +110,10 @@ fun TextField(
     val borderWidth by animateDpAsState(if (isFocused) 2.dp else 0.dp)
     val animatedBorderColor by animateColorAsState(if (isFocused) borderColor else backgroundColor)
     val borderShape = remember(cornerRadius) { RoundedCornerShape(cornerRadius) }
-    val finalModifier = Modifier.background(backgroundColor, borderShape).border(borderWidth, animatedBorderColor, borderShape)
-    val labelState by remember(state.text, label, useLabelAsPlaceholder) {
+    val finalModifier = remember(backgroundColor, borderWidth, animatedBorderColor, borderShape) {
+        Modifier.background(backgroundColor, borderShape).border(borderWidth, animatedBorderColor, borderShape)
+    }
+    val labelState by remember(label, useLabelAsPlaceholder) {
         derivedStateOf {
             when {
                 label.isEmpty() -> LabelAnimState.Hidden
@@ -136,27 +136,29 @@ fun TextField(
             else -> 17.dp
         },
     )
-    val paddingModifier by remember(leadingIcon, trailingIcon, insideMargin) {
-        derivedStateOf {
-            when {
-                leadingIcon == null && trailingIcon == null -> Modifier.padding(insideMargin.width, vertical = insideMargin.height)
-                leadingIcon == null -> Modifier.padding(start = insideMargin.width).padding(vertical = insideMargin.height)
-                trailingIcon == null -> Modifier.padding(end = insideMargin.width).padding(vertical = insideMargin.height)
-                else -> Modifier.padding(vertical = insideMargin.height)
-            }
+    val paddingModifier = remember(leadingIcon, trailingIcon, insideMargin) {
+        when {
+            leadingIcon == null && trailingIcon == null -> Modifier.padding(insideMargin.width, vertical = insideMargin.height)
+            leadingIcon == null -> Modifier.padding(start = insideMargin.width).padding(vertical = insideMargin.height)
+            trailingIcon == null -> Modifier.padding(end = insideMargin.width).padding(vertical = insideMargin.height)
+            else -> Modifier.padding(vertical = insideMargin.height)
         }
     }
 
     val currentOnTextLayout by rememberUpdatedState(onTextLayout)
 
-    val textColor = textStyle.color.takeOrElse { LocalContentColor.current }
+    val contentColor = LocalContentColor.current
+    val resolvedTextStyle = remember(textStyle, contentColor) {
+        val textColor = textStyle.color.takeOrElse { contentColor }
+        textStyle.copy(textColor)
+    }
 
     BasicTextField(
         state = state,
         modifier = modifier,
         enabled = enabled,
         readOnly = readOnly,
-        textStyle = textStyle.copy(textColor),
+        textStyle = resolvedTextStyle,
         cursorBrush = cursorBrush,
         keyboardOptions = keyboardOptions,
         onKeyboardAction = onKeyboardAction,
@@ -218,7 +220,6 @@ fun TextField(
  * @param cursorBrush The brush to be used for the cursor.
  */
 @Composable
-@NonRestartableComposable
 fun TextField(
     value: TextFieldValue,
     onValueChange: (TextFieldValue) -> Unit,
@@ -251,15 +252,15 @@ fun TextField(
     val borderWidth by animateDpAsState(if (isFocused) 2.dp else 0.dp)
     val animatedBorderColor by animateColorAsState(if (isFocused) borderColor else backgroundColor)
     val borderShape = remember(cornerRadius) { RoundedCornerShape(cornerRadius) }
-    val finalModifier = Modifier.background(backgroundColor, borderShape).border(borderWidth, animatedBorderColor, borderShape)
-    val labelState by remember(value.text, label, useLabelAsPlaceholder) {
-        derivedStateOf {
-            when {
-                label.isEmpty() -> LabelAnimState.Hidden
-                useLabelAsPlaceholder && value.text.isNotEmpty() -> LabelAnimState.Placeholder
-                value.text.isNotEmpty() -> LabelAnimState.Floating
-                else -> LabelAnimState.Normal
-            }
+    val finalModifier = remember(backgroundColor, borderWidth, animatedBorderColor, borderShape) {
+        Modifier.background(backgroundColor, borderShape).border(borderWidth, animatedBorderColor, borderShape)
+    }
+    val labelState = remember(value.text, label, useLabelAsPlaceholder) {
+        when {
+            label.isEmpty() -> LabelAnimState.Hidden
+            useLabelAsPlaceholder && value.text.isNotEmpty() -> LabelAnimState.Placeholder
+            value.text.isNotEmpty() -> LabelAnimState.Floating
+            else -> LabelAnimState.Normal
         }
     }
     val labelAnim by animateDpAsState(
@@ -275,21 +276,23 @@ fun TextField(
             else -> 17.dp
         },
     )
-    val paddingModifier by remember(leadingIcon, trailingIcon, insideMargin) {
-        derivedStateOf {
-            when {
-                leadingIcon == null && trailingIcon == null -> Modifier.padding(insideMargin.width, vertical = insideMargin.height)
-                leadingIcon == null -> Modifier.padding(start = insideMargin.width).padding(vertical = insideMargin.height)
-                trailingIcon == null -> Modifier.padding(end = insideMargin.width).padding(vertical = insideMargin.height)
-                else -> Modifier.padding(vertical = insideMargin.height)
-            }
+    val paddingModifier = remember(leadingIcon, trailingIcon, insideMargin) {
+        when {
+            leadingIcon == null && trailingIcon == null -> Modifier.padding(insideMargin.width, vertical = insideMargin.height)
+            leadingIcon == null -> Modifier.padding(start = insideMargin.width).padding(vertical = insideMargin.height)
+            trailingIcon == null -> Modifier.padding(end = insideMargin.width).padding(vertical = insideMargin.height)
+            else -> Modifier.padding(vertical = insideMargin.height)
         }
     }
 
     val currentOnValueChange by rememberUpdatedState(onValueChange)
     val currentOnTextLayout by rememberUpdatedState(onTextLayout)
 
-    val textColor = textStyle.color.takeOrElse { LocalContentColor.current }
+    val contentColor = LocalContentColor.current
+    val resolvedTextStyle = remember(textStyle, contentColor) {
+        val textColor = textStyle.color.takeOrElse { contentColor }
+        textStyle.copy(textColor)
+    }
 
     BasicTextField(
         value = value,
@@ -297,7 +300,7 @@ fun TextField(
         modifier = modifier,
         enabled = enabled,
         readOnly = readOnly,
-        textStyle = textStyle.copy(textColor),
+        textStyle = resolvedTextStyle,
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
         singleLine = singleLine,
@@ -355,7 +358,6 @@ fun TextField(
  * @param cursorBrush The brush to be used for the cursor.
  */
 @Composable
-@NonRestartableComposable
 fun TextField(
     value: String,
     onValueChange: (String) -> Unit,
@@ -388,15 +390,15 @@ fun TextField(
     val borderWidth by animateDpAsState(if (isFocused) 2.dp else 0.dp)
     val animatedBorderColor by animateColorAsState(if (isFocused) borderColor else backgroundColor)
     val borderShape = remember(cornerRadius) { RoundedCornerShape(cornerRadius) }
-    val finalModifier = Modifier.background(backgroundColor, borderShape).border(borderWidth, animatedBorderColor, borderShape)
-    val labelState by remember(value, label, useLabelAsPlaceholder) {
-        derivedStateOf {
-            when {
-                label.isEmpty() -> LabelAnimState.Hidden
-                useLabelAsPlaceholder && value.isNotEmpty() -> LabelAnimState.Placeholder
-                value.isNotEmpty() -> LabelAnimState.Floating
-                else -> LabelAnimState.Normal
-            }
+    val finalModifier = remember(backgroundColor, borderWidth, animatedBorderColor, borderShape) {
+        Modifier.background(backgroundColor, borderShape).border(borderWidth, animatedBorderColor, borderShape)
+    }
+    val labelState = remember(value, label, useLabelAsPlaceholder) {
+        when {
+            label.isEmpty() -> LabelAnimState.Hidden
+            useLabelAsPlaceholder && value.isNotEmpty() -> LabelAnimState.Placeholder
+            value.isNotEmpty() -> LabelAnimState.Floating
+            else -> LabelAnimState.Normal
         }
     }
     val labelAnim by animateDpAsState(
@@ -412,21 +414,23 @@ fun TextField(
             else -> 17.dp
         },
     )
-    val paddingModifier by remember(leadingIcon, trailingIcon, insideMargin) {
-        derivedStateOf {
-            when {
-                leadingIcon == null && trailingIcon == null -> Modifier.padding(insideMargin.width, vertical = insideMargin.height)
-                leadingIcon == null -> Modifier.padding(start = insideMargin.width).padding(vertical = insideMargin.height)
-                trailingIcon == null -> Modifier.padding(end = insideMargin.width).padding(vertical = insideMargin.height)
-                else -> Modifier.padding(vertical = insideMargin.height)
-            }
+    val paddingModifier = remember(leadingIcon, trailingIcon, insideMargin) {
+        when {
+            leadingIcon == null && trailingIcon == null -> Modifier.padding(insideMargin.width, vertical = insideMargin.height)
+            leadingIcon == null -> Modifier.padding(start = insideMargin.width).padding(vertical = insideMargin.height)
+            trailingIcon == null -> Modifier.padding(end = insideMargin.width).padding(vertical = insideMargin.height)
+            else -> Modifier.padding(vertical = insideMargin.height)
         }
     }
 
     val currentOnValueChange by rememberUpdatedState(onValueChange)
     val currentOnTextLayout by rememberUpdatedState(onTextLayout)
 
-    val textColor = textStyle.color.takeOrElse { LocalContentColor.current }
+    val contentColor = LocalContentColor.current
+    val resolvedTextStyle = remember(textStyle, contentColor) {
+        val textColor = textStyle.color.takeOrElse { contentColor }
+        textStyle.copy(textColor)
+    }
 
     BasicTextField(
         value = value,
@@ -434,7 +438,7 @@ fun TextField(
         modifier = modifier,
         enabled = enabled,
         readOnly = readOnly,
-        textStyle = textStyle.copy(textColor),
+        textStyle = resolvedTextStyle,
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
         singleLine = singleLine,

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/TopAppBar.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/TopAppBar.kt
@@ -89,7 +89,6 @@ import kotlin.math.roundToInt
  * @param horizontalPadding The horizontal padding of the [TopAppBar]'s title & large title.
  */
 @Composable
-@NonRestartableComposable
 fun TopAppBar(
     title: String,
     modifier: Modifier = Modifier,

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperDropdown.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperDropdown.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -53,7 +52,6 @@ import top.yukonga.miuix.kmp.theme.MiuixTheme
  * @param onSelectedIndexChange The callback when the selected index of the [SuperDropdown] is changed.
  */
 @Composable
-@NonRestartableComposable
 fun SuperDropdown(
     items: List<String>,
     selectedIndex: Int,

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperSpinner.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/SuperSpinner.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -62,7 +61,6 @@ import top.yukonga.miuix.kmp.theme.MiuixTheme
  * @param onSelectedIndexChange The callback to be invoked when the selected index of the [SuperSpinner] is changed.
  */
 @Composable
-@NonRestartableComposable
 fun SuperSpinner(
     items: List<SpinnerEntry>,
     selectedIndex: Int,
@@ -206,7 +204,6 @@ private fun SuperSpinnerPopup(
  * @param onSelectedIndexChange the callback to be invoked when the selected index of the [SuperSpinner] is changed.
  */
 @Composable
-@NonRestartableComposable
 fun SuperSpinner(
     items: List<SpinnerEntry>,
     selectedIndex: Int,

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/WindowDropdown.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/WindowDropdown.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -53,7 +52,6 @@ import top.yukonga.miuix.kmp.theme.MiuixTheme
  * @param onSelectedIndexChange The callback when the selected index of the [WindowDropdown] is changed.
  */
 @Composable
-@NonRestartableComposable
 fun WindowDropdown(
     items: List<String>,
     selectedIndex: Int,

--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/WindowSpinner.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/extra/WindowSpinner.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -62,7 +61,6 @@ import top.yukonga.miuix.kmp.theme.MiuixTheme
  * @param onSelectedIndexChange The callback to be invoked when the selected index of the [WindowSpinner] is changed.
  */
 @Composable
-@NonRestartableComposable
 fun WindowSpinner(
     items: List<SpinnerEntry>,
     selectedIndex: Int,
@@ -207,7 +205,6 @@ private fun WindowSpinnerPopup(
  * @param onSelectedIndexChange the callback to be invoked when the selected index of the [WindowSpinner] is changed.
  */
 @Composable
-@NonRestartableComposable
 fun WindowSpinner(
     items: List<SpinnerEntry>,
     selectedIndex: Int,


### PR DESCRIPTION
- Remove `@NonRestartableComposable` annotations from various UI components (Surface, TabRow, TopAppBar, TextField, etc.) to allow for more efficient recomposition.
- Optimize `TextField` by wrapping `Modifier` and `TextStyle` calculations in `remember` blocks and replacing `derivedStateOf` with simpler `remember` calls where appropriate.
- Refactor `ProgressIndicator` components to reduce redundant property lookups and simplify drawing logic into helper functions.
- Improve `PullToRefresh` and `Slider` components by properly memoizing `Modifier` chains, `AnimationSpec` instances, and pointer input handlers using `remember`.
- Optimize `Icon` by removing unnecessary `derivedStateOf` and `rememberUpdatedState` calls.