### PR TITLE
library: SearchBar: change font weight to Medium

### DIFF
--- a/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/SearchBar.kt
+++ b/miuix/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/SearchBar.kt
@@ -203,7 +203,7 @@ fun InputField(
 
     val textColor = LocalContentColor.current
     val inputTextStyle = MiuixTheme.textStyles.main
-        .copy(fontWeight = FontWeight.Bold)
+        .copy(fontWeight = FontWeight.Medium)
         .merge(textStyle)
         .copy(color = textColor)
 
@@ -253,7 +253,7 @@ fun InputField(
                     ) {
                         Text(
                             text = labelText,
-                            style = TextStyle(fontSize = 17.sp, fontWeight = FontWeight.Bold).merge(textStyle),
+                            style = TextStyle(fontSize = 17.sp, fontWeight = FontWeight.Medium).merge(textStyle),
                             color = MiuixTheme.colorScheme.onSurfaceContainerHigh,
                         )
                         innerTextField()


### PR DESCRIPTION
Updates the `inputTextStyle` and label text style in `SearchBar` to use `FontWeight.Medium` instead of `FontWeight.Bold`.