### PR TITLE
fix: TabRow scroll state persistence

### DIFF
--- a/docs/components/tabrow.md
+++ b/docs/components/tabrow.md
@@ -41,6 +41,21 @@ TabRowWithContour(
 )
 ```
 
+### Preserve Scroll Position
+
+```kotlin
+val tabs = listOf("Tab 1", "Tab 2", "Tab 3", "Tab 4", "Tab 5")
+var selectedTabIndex by remember { mutableStateOf(3) }
+val tabListState = rememberLazyListState()
+
+TabRowWithContour(
+    tabs = tabs,
+    selectedTabIndex = selectedTabIndex,
+    onTabSelected = { selectedTabIndex = it },
+    listState = tabListState,
+)
+```
+
 ## Properties
 
 ### TabRow Properties
@@ -58,6 +73,7 @@ TabRowWithContour(
 | cornerRadius      | Dp                        | Corner radius of tabs            | TabRowDefaults.TabRowCornerRadius | No       |
 | itemSpacing       | Dp                        | Spacing between tabs             | 9.dp                              | No       |
 | contentAlignment  | Alignment                 | Alignment of tab content         | Alignment.Center                  | No       |
+| listState         | LazyListState?            | External scroll state for tabs   | null                              | No       |
 | interactionSource | MutableInteractionSource? | Interaction source for tab items | null                              | No       |
 | indication        | Indication?               | Indication for tab items         | null                              | No       |
 
@@ -76,6 +92,7 @@ TabRowWithContour(
 | cornerRadius      | Dp                        | Corner radius of tabs            | TabRowDefaults.TabRowWithContourCornerRadius | No       |
 | itemSpacing       | Dp                        | Spacing between tabs             | 5.dp                                         | No       |
 | contentAlignment  | Alignment                 | Alignment of tab content         | Alignment.Center                             | No       |
+| listState         | LazyListState?            | External scroll state for tabs   | null                                         | No       |
 | interactionSource | MutableInteractionSource? | Interaction source for tab items | null                                         | No       |
 | indication        | Indication?               | Indication for tab items         | null                                         | No       |
 

--- a/docs/demo/src/commonMain/kotlin/TabRowDemo.kt
+++ b/docs/demo/src/commonMain/kotlin/TabRowDemo.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -40,19 +41,24 @@ fun TabRowDemo() {
         ) {
             val tabs1 = listOf("Recommended", "Following", "Popular", "Featured")
             var selectedTabIndex1 by remember { mutableIntStateOf(0) }
+            val tabListState1 = rememberLazyListState()
 
             TabRow(
                 tabs = tabs1,
                 selectedTabIndex = selectedTabIndex1,
                 onTabSelected = { selectedTabIndex1 = it },
+                listState = tabListState1,
             )
+
             val tabs2 = listOf("All", "Photos", "Videos", "Documents")
             var selectedTabIndex2 by remember { mutableIntStateOf(0) }
+            val contourTabListState2 = rememberLazyListState()
 
             TabRowWithContour(
                 tabs = tabs2,
                 selectedTabIndex = selectedTabIndex2,
                 onTabSelected = { selectedTabIndex2 = it },
+                listState = contourTabListState2,
             )
         }
     }

--- a/docs/zh_CN/components/tabrow.md
+++ b/docs/zh_CN/components/tabrow.md
@@ -41,6 +41,21 @@ TabRowWithContour(
 )
 ```
 
+### 记住滚动位置
+
+```kotlin
+val tabs = listOf("标签1", "标签2", "标签3", "标签4", "标签5")
+var selectedTabIndex by remember { mutableStateOf(3) }
+val tabListState = rememberLazyListState()
+
+TabRowWithContour(
+    tabs = tabs,
+    selectedTabIndex = selectedTabIndex,
+    onTabSelected = { selectedTabIndex = it },
+    listState = tabListState,
+)
+```
+
 ## 属性
 
 ### TabRow 属性
@@ -58,6 +73,7 @@ TabRowWithContour(
 | cornerRadius      | Dp                        | 标签的圆角半径       | TabRowDefaults.TabRowCornerRadius | 否       |
 | itemSpacing       | Dp                        | 标签之间的间距       | 9.dp                              | 否       |
 | contentAlignment  | Alignment                 | 标签内容的对齐方式   | Alignment.Center                  | 否       |
+| listState         | LazyListState?            | 标签列表的外部滚动状态 | null                            | 否       |
 | interactionSource | MutableInteractionSource? | 标签项的交互源       | null                              | 否       |
 | indication        | Indication?               | 标签项的点击反馈效果 | null                              | 否       |
 
@@ -76,6 +92,7 @@ TabRowWithContour(
 | cornerRadius      | Dp                        | 标签的圆角半径       | TabRowDefaults.TabRowWithContourCornerRadius | 否       |
 | itemSpacing       | Dp                        | 标签之间的间距       | 5.dp                                         | 否       |
 | contentAlignment  | Alignment                 | 标签内容的对齐方式   | Alignment.Center                             | 否       |
+| listState         | LazyListState?            | 标签列表的外部滚动状态 | null                                      | 否       |
 | interactionSource | MutableInteractionSource? | 标签项的交互源       | null                                         | 否       |
 | indication        | Indication?               | 标签项的点击反馈效果 | null                                         | 否       |
 

--- a/example/shared/src/commonMain/kotlin/component/TabRowSection.kt
+++ b/example/shared/src/commonMain/kotlin/component/TabRowSection.kt
@@ -6,6 +6,7 @@ package component
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -29,12 +30,14 @@ fun LazyListScope.tabRowSection() {
         val tabTexts = remember { listOf("Tab 1", "Tab 2", "Tab 3") }
         val tabTexts1 = remember { listOf("Tab 1", "Tab 2", "Tab 3", "Tab 4", "Tab 5", "Tab 6") }
         var selectedTabIndex by remember { mutableIntStateOf(0) }
+        val tabListState = rememberLazyListState()
         TabRow(
             tabs = tabTexts,
             selectedTabIndex = selectedTabIndex,
             onTabSelected = {
                 selectedTabIndex = it
             },
+            listState = tabListState,
             modifier = Modifier
                 .padding(horizontal = 12.dp)
                 .padding(bottom = 12.dp),
@@ -48,6 +51,7 @@ fun LazyListScope.tabRowSection() {
         ) {
             val scope = rememberCoroutineScope()
             val pagerState = rememberPagerState(pageCount = { tabTexts1.size })
+            val contourTabListState = rememberLazyListState()
             TabRowWithContour(
                 tabs = tabTexts1,
                 selectedTabIndex = pagerState.currentPage,
@@ -56,6 +60,7 @@ fun LazyListScope.tabRowSection() {
                         pagerState.animateScrollToPage(it)
                     }
                 },
+                listState = contourTabListState,
             )
             HorizontalPager(
                 state = pagerState,

--- a/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/TabRow.kt
+++ b/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/TabRow.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -29,8 +30,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -64,6 +67,7 @@ import kotlin.math.roundToInt
  * @param cornerRadius The round corner radius of the tab in [TabRow].
  * @param itemSpacing The spacing between tabs in [TabRow].
  * @param contentAlignment The content alignment of the tab in [TabRow].
+ * @param listState The [LazyListState] to be used for the [TabRow].
  * @param interactionSource The [MutableInteractionSource] to be used for the [TabRow].
  * @param indication The [Indication] to be used for the [TabRow].
  */
@@ -80,6 +84,7 @@ fun TabRow(
     cornerRadius: Dp = TabRowDefaults.TabRowCornerRadius,
     itemSpacing: Dp = 9.dp,
     contentAlignment: Alignment = Alignment.Center,
+    listState: LazyListState? = null,
     interactionSource: MutableInteractionSource? = null,
     indication: Indication? = null,
 ) {
@@ -92,22 +97,40 @@ fun TabRow(
             .height(height)
             .background(color = colors.backgroundColor(false)),
     ) {
-        val config = rememberTabRowConfig(tabs, minWidth, maxWidth, cornerRadius, itemSpacing, this.maxWidth)
+        val config = rememberTabRowConfig(
+            tabs = tabs,
+            minWidth = minWidth,
+            maxWidth = maxWidth,
+            cornerRadius = cornerRadius,
+            spacing = itemSpacing,
+            lazyRowAvailableWidth = this.maxWidth,
+            listState = listState,
+        )
         val density = LocalDensity.current
         val tabWidthPx = with(density) { config.tabWidth.toPx() }
         val spacingPx = with(density) { itemSpacing.toPx() }
         val indicatorOffset = remember { Animatable(0f) }
         val availableWidth = this.maxWidth
+        var lastSettledSelectedTabIndex by remember(config.listState) { mutableIntStateOf(-1) }
 
         LaunchedEffect(selectedTabIndex, tabWidthPx, spacingPx) {
             val target = selectedTabIndex * (tabWidthPx + spacingPx)
-            indicatorOffset.animateTo(target, tween(200, easing = LinearEasing))
+            if (lastSettledSelectedTabIndex < 0 || lastSettledSelectedTabIndex == selectedTabIndex) {
+                indicatorOffset.snapTo(target)
+            } else {
+                indicatorOffset.animateTo(target, tween(200, easing = LinearEasing))
+            }
         }
 
         LaunchedEffect(selectedTabIndex, availableWidth) {
             val centerOffset = (availableWidth - config.tabWidth) / 2
             val offsetPx = with(density) { -centerOffset.toPx() }.roundToInt()
-            config.listState.animateScrollToItem(selectedTabIndex, offsetPx)
+            if (lastSettledSelectedTabIndex < 0 || lastSettledSelectedTabIndex == selectedTabIndex) {
+                config.listState.scrollToItem(selectedTabIndex, offsetPx)
+            } else {
+                config.listState.animateScrollToItem(selectedTabIndex, offsetPx)
+            }
+            lastSettledSelectedTabIndex = selectedTabIndex
         }
 
         val scrollOffset by remember {
@@ -168,6 +191,7 @@ fun TabRow(
  * @param cornerRadius The round corner radius of the tab in [TabRow].
  * @param itemSpacing The spacing between tabs in [TabRow].
  * @param contentAlignment The content alignment of the tab in [TabRow].
+ * @param listState The [LazyListState] to be used for the [TabRow].
  * @param interactionSource The [MutableInteractionSource] to be used for the [TabRow].
  * @param indication The [Indication] to be used for the [TabRow].
  */
@@ -184,6 +208,7 @@ fun TabRowWithContour(
     cornerRadius: Dp = TabRowDefaults.TabRowWithContourCornerRadius,
     itemSpacing: Dp = 5.dp,
     contentAlignment: Alignment = Alignment.Center,
+    listState: LazyListState? = null,
     interactionSource: MutableInteractionSource? = null,
     indication: Indication? = null,
 ) {
@@ -198,22 +223,40 @@ fun TabRowWithContour(
             .height(height),
     ) {
         val lazyRowAvailableWidth = this.maxWidth - (contourPadding * 2)
-        val config = rememberTabRowConfig(tabs, minWidth, maxWidth, cornerRadius, itemSpacing, lazyRowAvailableWidth)
+        val config = rememberTabRowConfig(
+            tabs = tabs,
+            minWidth = minWidth,
+            maxWidth = maxWidth,
+            cornerRadius = cornerRadius,
+            spacing = itemSpacing,
+            lazyRowAvailableWidth = lazyRowAvailableWidth,
+            listState = listState,
+        )
         val density = LocalDensity.current
         val tabWidthPx = with(density) { config.tabWidth.toPx() }
         val spacingPx = with(density) { itemSpacing.toPx() }
         val indicatorOffset = remember { Animatable(0f) }
         val availableWidth = this.maxWidth
+        var lastSettledSelectedTabIndex by remember(config.listState) { mutableIntStateOf(-1) }
 
         LaunchedEffect(selectedTabIndex, tabWidthPx, spacingPx) {
             val target = selectedTabIndex * (tabWidthPx + spacingPx)
-            indicatorOffset.animateTo(target, tween(200, easing = LinearEasing))
+            if (lastSettledSelectedTabIndex < 0 || lastSettledSelectedTabIndex == selectedTabIndex) {
+                indicatorOffset.snapTo(target)
+            } else {
+                indicatorOffset.animateTo(target, tween(200, easing = LinearEasing))
+            }
         }
 
         LaunchedEffect(selectedTabIndex, availableWidth) {
             val centerOffset = (availableWidth - (contourPadding * 2) - config.tabWidth) / 2
             val offsetPx = with(density) { -centerOffset.toPx() }.roundToInt()
-            config.listState.animateScrollToItem(selectedTabIndex, offsetPx)
+            if (lastSettledSelectedTabIndex < 0 || lastSettledSelectedTabIndex == selectedTabIndex) {
+                config.listState.scrollToItem(selectedTabIndex, offsetPx)
+            } else {
+                config.listState.animateScrollToItem(selectedTabIndex, offsetPx)
+            }
+            lastSettledSelectedTabIndex = selectedTabIndex
         }
 
         val scrollOffset by remember {
@@ -367,14 +410,15 @@ private fun rememberTabRowConfig(
     cornerRadius: Dp,
     spacing: Dp,
     lazyRowAvailableWidth: Dp,
+    listState: LazyListState? = null,
 ): TabRowConfig {
-    val listState = rememberLazyListState()
+    val resolvedListState = listState ?: rememberLazyListState()
     val tabWidth = remember(tabs.size, minWidth, maxWidth, lazyRowAvailableWidth, spacing) {
         calculateTabWidth(tabs.size, minWidth, maxWidth, spacing, lazyRowAvailableWidth)
     }
     val shape = miuixShape(cornerRadius)
 
-    return TabRowConfig(tabWidth, shape, listState)
+    return TabRowConfig(tabWidth, shape, resolvedListState)
 }
 
 private fun calculateTabWidth(

--- a/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/TabRow.kt
+++ b/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/TabRow.kt
@@ -122,7 +122,7 @@ fun TabRow(
             }
         }
 
-        LaunchedEffect(selectedTabIndex, availableWidth) {
+        LaunchedEffect(selectedTabIndex, availableWidth, config.listState, config.tabWidth) {
             val centerOffset = (availableWidth - config.tabWidth) / 2
             val offsetPx = with(density) { -centerOffset.toPx() }.roundToInt()
             if (lastSettledSelectedTabIndex < 0 || lastSettledSelectedTabIndex == selectedTabIndex) {
@@ -248,7 +248,7 @@ fun TabRowWithContour(
             }
         }
 
-        LaunchedEffect(selectedTabIndex, availableWidth) {
+        LaunchedEffect(selectedTabIndex, availableWidth, config.listState, config.tabWidth) {
             val centerOffset = (availableWidth - (contourPadding * 2) - config.tabWidth) / 2
             val offsetPx = with(density) { -centerOffset.toPx() }.roundToInt()
             if (lastSettledSelectedTabIndex < 0 || lastSettledSelectedTabIndex == selectedTabIndex) {


### PR DESCRIPTION
目前带状态重组的时候会看到 TabRow 从第一个选项跳过来，因此加上外部传入的 `LazyListState`