### PR TITLE
example: Add OS3 background effect and configuration

### DIFF
--- a/example/shared/src/commonMain/kotlin/AboutPage.kt
+++ b/example/shared/src/commonMain/kotlin/AboutPage.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -40,11 +41,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -62,7 +65,12 @@ import org.jetbrains.compose.resources.painterResource
 import top.yukonga.miuix.kmp.basic.BasicComponent
 import top.yukonga.miuix.kmp.basic.Card
 import top.yukonga.miuix.kmp.basic.CardDefaults
+import top.yukonga.miuix.kmp.basic.DropdownArrowEndAction
+import top.yukonga.miuix.kmp.basic.DropdownDefaults
+import top.yukonga.miuix.kmp.basic.DropdownImpl
+import top.yukonga.miuix.kmp.basic.ListPopupColumn
 import top.yukonga.miuix.kmp.basic.MiuixScrollBehavior
+import top.yukonga.miuix.kmp.basic.PopupPositionProvider
 import top.yukonga.miuix.kmp.basic.Scaffold
 import top.yukonga.miuix.kmp.basic.ScrollBehavior
 import top.yukonga.miuix.kmp.basic.Slider
@@ -83,10 +91,12 @@ import top.yukonga.miuix.kmp.blur.rememberLayerBackdrop
 import top.yukonga.miuix.kmp.blur.textureBlur
 import top.yukonga.miuix.kmp.interfaces.ExperimentalScrollBarApi
 import top.yukonga.miuix.kmp.overlay.OverlayBottomSheet
+import top.yukonga.miuix.kmp.overlay.OverlayListPopup
 import top.yukonga.miuix.kmp.preference.ArrowPreference
 import top.yukonga.miuix.kmp.shapes.SmoothRoundedCornerShape
 import top.yukonga.miuix.kmp.shared.generated.resources.Res
 import top.yukonga.miuix.kmp.shared.generated.resources.ic_launcher
+import top.yukonga.miuix.kmp.theme.LocalDismissState
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 import top.yukonga.miuix.kmp.theme.MiuixTheme.colorScheme
 import ui.isInDarkTheme
@@ -158,6 +168,7 @@ private fun AboutContent(
     val navigator = LocalNavigator.current
 
     val backdrop = rememberLayerBackdrop()
+    var isOs3Effect by remember { mutableStateOf(true) }
     var showTextureSet by remember { mutableStateOf(false) }
     var blurRadius by remember { mutableFloatStateOf(60f) }
     var noiseCoefficient by remember { mutableFloatStateOf(BlurDefaults.NoiseCoefficient) }
@@ -273,6 +284,7 @@ private fun AboutContent(
 
     BgEffectBackground(
         dynamicBackground = dynamicBackground.value,
+        isOs3Effect = isOs3Effect,
         modifier = Modifier.fillMaxSize(),
         bgModifier = Modifier.layerBackdrop(backdrop),
         effectBackground = effectBackground.value,
@@ -515,141 +527,212 @@ private fun AboutContent(
     ) {
         LazyColumn {
             item {
-                Card {
-                    BasicComponent(
-                        title = "Effect Background Enabled",
-                        endActions = {
-                            Switch(
-                                effectBackground.value,
-                                {
-                                    effectBackground.value = it
-                                },
-                            )
-                        },
-                        insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
-                    )
-                    BasicComponent(
-                        title = "Dynamic Background Enabled",
-                        endActions = {
-                            Switch(
-                                dynamicBackground.value,
-                                {
-                                    dynamicBackground.value = it
-                                },
-                            )
-                        },
-                        insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
-                    )
-                    BasicComponent(
-                        title = "Blur Enable",
-                        endActions = {
-                            Switch(
-                                blurEnable,
-                                {
-                                    blurEnable = it
-                                },
-                            )
-                        },
-                        insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
-                    )
-                    // Blur radius
-                    BasicComponent(
-                        title = "Blur Radius",
-                        endActions = { ValueText("${blurRadius.toInt()}") },
-                        bottomAction = {
-                            Slider(
-                                value = blurRadius / 200f,
-                                onValueChange = { blurRadius = it * 200f },
-                            )
-                        },
-                        insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
-                    )
+                val effectVariantOptions = listOf("OS2", "OS3")
+                val selectedIndex = if (isOs3Effect) 1 else 0
+                var isDropdownExpanded by remember { mutableStateOf(false) }
+                var isHoldDown by remember { mutableStateOf(false) }
+                val hapticFeedback = LocalHapticFeedback.current
 
-                    // Noise
-                    BasicComponent(
-                        title = "Noise",
-                        endActions = { ValueText("${(noiseCoefficient * 10000).toInt() / 10000f}") },
-                        bottomAction = {
-                            Slider(
-                                value = noiseCoefficient / 0.1f,
-                                onValueChange = { noiseCoefficient = it * 0.1f },
-                            )
-                        },
-                        insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
-                    )
+                BasicComponent(
+                    title = "Effect Variant",
+                    insideMargin = PaddingValues(16.dp, 0.dp, 16.dp, 0.dp),
+                    onClick = {
+                        isDropdownExpanded = !isDropdownExpanded
+                        if (isDropdownExpanded) {
+                            isHoldDown = true
+                            hapticFeedback.performHapticFeedback(HapticFeedbackType.ContextClick)
+                        }
+                    },
+                    holdDownState = isHoldDown,
+                    endActions = {
+                        Text(
+                            text = effectVariantOptions[selectedIndex],
+                            modifier = Modifier
+                                .padding(end = 8.dp)
+                                .align(Alignment.CenterVertically),
+                            fontSize = MiuixTheme.textStyles.body2.fontSize,
+                            color = colorScheme.onSurfaceVariantActions,
+                            textAlign = TextAlign.End,
+                        )
 
-                    // Brightness
-                    BasicComponent(
-                        title = "Brightness",
-                        endActions = { ValueText("${(brightness * 100).toInt() / 100f}") },
-                        bottomAction = {
-                            Slider(
-                                value = (brightness + 1f) / 2f,
-                                onValueChange = { brightness = it * 2f - 1f },
-                            )
-                        },
-                        insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
-                    )
+                        DropdownArrowEndAction(
+                            actionColor = colorScheme.onSurfaceVariantActions,
+                        )
 
-                    // Contrast
-                    BasicComponent(
-                        title = "Contrast",
-                        endActions = { ValueText("${(contrast * 100).toInt() / 100f}") },
-                        bottomAction = {
-                            Slider(
-                                value = contrast / 3f,
-                                onValueChange = { contrast = it * 3f },
-                            )
-                        },
-                        insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
-                    )
-
-                    // Saturation
-                    BasicComponent(
-                        title = "Saturation",
-                        endActions = { ValueText("${(saturation * 100).toInt() / 100f}") },
-                        bottomAction = {
-                            Slider(
-                                value = saturation / 3f,
-                                onValueChange = { saturation = it * 3f },
-                            )
-                        },
-                        insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
-                    )
-
-                    // Blend mode
-                    val currentConfigName = configEntries.getOrNull(blendModeIndex)?.key ?: "Default"
-                    val modeId = blendConfigs[currentConfigName]
-                    BasicComponent(
-                        title = "Blend Mode",
-                        endActions = {
-                            ValueText(currentConfigName + if (modeId != null) " ($modeId)" else "")
-                        },
-                        bottomAction = {
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                            ) {
-                                TextButton(
-                                    text = "Prev",
-                                    onClick = {
-                                        blendModeIndex = (blendModeIndex - 1 + blendConfigs.size) % blendConfigs.size
-                                    },
-                                    modifier = Modifier.weight(1f),
-                                )
-                                TextButton(
-                                    text = "Next",
-                                    onClick = {
-                                        blendModeIndex = (blendModeIndex + 1) % blendConfigs.size
-                                    },
-                                    modifier = Modifier.weight(1f),
-                                )
+                        OverlayListPopup(
+                            show = isDropdownExpanded,
+                            alignment = PopupPositionProvider.Align.End,
+                            onDismissRequest = { isDropdownExpanded = false },
+                            onDismissFinished = { isHoldDown = false },
+                        ) {
+                            val dismiss = LocalDismissState.current
+                            ListPopupColumn {
+                                effectVariantOptions.forEachIndexed { index, text ->
+                                    key(index) {
+                                        DropdownImpl(
+                                            text = text,
+                                            optionSize = effectVariantOptions.size,
+                                            isSelected = selectedIndex == index,
+                                            dropdownColors = DropdownDefaults.dropdownColors(),
+                                            index = index,
+                                            onSelectedIndexChange = { selectedIdx ->
+                                                hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                                                isOs3Effect = (selectedIdx == 1)
+                                                dismiss?.invoke()
+                                            },
+                                        )
+                                    }
+                                }
                             }
-                        },
-                    )
-                    Spacer(modifier = Modifier.height(WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()))
-                }
+                        }
+                    },
+                )
             }
+            item {
+                BasicComponent(
+                    title = "Effect Background Enabled",
+                    endActions = {
+                        Switch(
+                            effectBackground.value,
+                            {
+                                effectBackground.value = it
+                            },
+                        )
+                    },
+                    insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
+                )
+            }
+            item {
+                BasicComponent(
+                    title = "Dynamic Background Enabled",
+                    endActions = {
+                        Switch(
+                            dynamicBackground.value,
+                            {
+                                dynamicBackground.value = it
+                            },
+                        )
+                    },
+                    insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
+                )
+            }
+            item {
+                BasicComponent(
+                    title = "Blur Enable",
+                    endActions = {
+                        Switch(
+                            blurEnable,
+                            {
+                                blurEnable = it
+                            },
+                        )
+                    },
+                    insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
+                )
+            }
+            item {
+                // Blur radius
+                BasicComponent(
+                    title = "Blur Radius",
+                    endActions = { ValueText("${blurRadius.toInt()}") },
+                    bottomAction = {
+                        Slider(
+                            value = blurRadius / 200f,
+                            onValueChange = { blurRadius = it * 200f },
+                        )
+                    },
+                    insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
+                )
+            }
+            item {
+                // Noise
+                BasicComponent(
+                    title = "Noise",
+                    endActions = { ValueText("${(noiseCoefficient * 10000).toInt() / 10000f}") },
+                    bottomAction = {
+                        Slider(
+                            value = noiseCoefficient / 0.1f,
+                            onValueChange = { noiseCoefficient = it * 0.1f },
+                        )
+                    },
+                    insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
+                )
+            }
+            item {
+                // Brightness
+                BasicComponent(
+                    title = "Brightness",
+                    endActions = { ValueText("${(brightness * 100).toInt() / 100f}") },
+                    bottomAction = {
+                        Slider(
+                            value = (brightness + 1f) / 2f,
+                            onValueChange = { brightness = it * 2f - 1f },
+                        )
+                    },
+                    insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
+                )
+            }
+            item {
+                // Contrast
+                BasicComponent(
+                    title = "Contrast",
+                    endActions = { ValueText("${(contrast * 100).toInt() / 100f}") },
+                    bottomAction = {
+                        Slider(
+                            value = contrast / 3f,
+                            onValueChange = { contrast = it * 3f },
+                        )
+                    },
+                    insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
+                )
+            }
+            item {
+                // Saturation
+                BasicComponent(
+                    title = "Saturation",
+                    endActions = { ValueText("${(saturation * 100).toInt() / 100f}") },
+                    bottomAction = {
+                        Slider(
+                            value = saturation / 3f,
+                            onValueChange = { saturation = it * 3f },
+                        )
+                    },
+                    insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
+                )
+            }
+            item {
+                // Blend mode
+                val currentConfigName = configEntries.getOrNull(blendModeIndex)?.key ?: "Default"
+                val modeId = blendConfigs[currentConfigName]
+                BasicComponent(
+                    title = "Blend Mode",
+                    endActions = {
+                        ValueText(currentConfigName + if (modeId != null) " ($modeId)" else "")
+                    },
+                    bottomAction = {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        ) {
+                            TextButton(
+                                text = "Prev",
+                                onClick = {
+                                    blendModeIndex = (blendModeIndex - 1 + blendConfigs.size) % blendConfigs.size
+                                },
+                                modifier = Modifier.weight(1f),
+                            )
+                            TextButton(
+                                text = "Next",
+                                onClick = {
+                                    blendModeIndex = (blendModeIndex + 1) % blendConfigs.size
+                                },
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                    },
+                )
+            }
+            item { Spacer(modifier = Modifier.height(WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding())) }
         }
     }
 }

--- a/example/shared/src/commonMain/kotlin/component/effect/BgEffectBackground.kt
+++ b/example/shared/src/commonMain/kotlin/component/effect/BgEffectBackground.kt
@@ -3,26 +3,32 @@
 
 package component.effect
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import top.yukonga.miuix.kmp.blur.asBrush
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import top.yukonga.miuix.kmp.blur.isRuntimeShaderSupported
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 import ui.isInDarkTheme
 
 @Composable
-inline fun BgEffectBackground(
+fun BgEffectBackground(
     dynamicBackground: Boolean,
     modifier: Modifier = Modifier,
     bgModifier: Modifier = Modifier,
     isFullSize: Boolean = false,
     effectBackground: Boolean = true,
-    crossinline alpha: () -> Float = { 1f },
+    isOs3Effect: Boolean = true,
+    alpha: () -> Float = { 1f },
     content: @Composable (BoxScope.() -> Unit),
 ) {
     val shaderSupported = remember { isRuntimeShaderSupported() }
@@ -34,30 +40,67 @@ inline fun BgEffectBackground(
         modifier = modifier,
     ) {
         val surface = MiuixTheme.colorScheme.surface
-        val painter = remember { BgEffectPainter() }
+        val painter = remember(isOs3Effect) { BgEffectPainter(isOs3Effect) }
         val animTime = rememberFrameTimeSeconds(dynamicBackground)
         val isDark = isInDarkTheme()
+        val deviceType = DeviceType.PHONE
 
-        Canvas(
-            modifier = Modifier
-                .fillMaxSize()
-                .then(bgModifier),
-        ) {
-            drawRect(surface)
-            if (effectBackground) {
-                val drawHeight = if (isFullSize) size.height else size.height * 0.78f
-                painter.updateResolution(
-                    size.width,
-                    size.height,
+        val preset = remember(isDark, deviceType, isOs3Effect) {
+            BgEffectConfig.get(deviceType, isDark, isOs3Effect)
+        }
+
+        val colorStage = remember { Animatable(0f) }
+
+        LaunchedEffect(dynamicBackground, preset) {
+            if (!dynamicBackground) return@LaunchedEffect
+            var targetStage = 1f
+            while (isActive) {
+                delay((preset.colorInterpPeriod * 500).toLong())
+                colorStage.animateTo(
+                    targetValue = targetStage,
+                    animationSpec = spring(dampingRatio = 0.9f, stiffness = 35f),
                 )
-                painter.updatePresetIfNeeded(
-                    drawHeight,
-                    size.height,
-                    size.width,
-                    isDark,
-                )
-                painter.updateAnimTime(animTime())
-                drawRect(painter.runtimeShader.asBrush(), alpha = alpha())
+                targetStage += 1f
+            }
+        }
+
+        key(isOs3Effect) {
+            Canvas(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .then(bgModifier),
+            ) {
+                drawRect(surface)
+                if (effectBackground) {
+                    val drawHeight = if (isFullSize) size.height else size.height * 0.78f
+
+                    val stage = colorStage.value
+                    val base = stage.toInt()
+                    val fraction = stage - base
+
+                    val getColors = { index: Int ->
+                        when (index % 4) {
+                            0 -> preset.colors2
+                            1 -> preset.colors1
+                            2 -> preset.colors2
+                            3 -> preset.colors3
+                            else -> preset.colors2
+                        }
+                    }
+
+                    val start = getColors(base)
+                    val end = getColors(base + 1)
+                    val currentColors = FloatArray(16) { i ->
+                        start[i] + (end[i] - start[i]) * fraction
+                    }
+
+                    painter.updateResolution(size.width, size.height)
+                    painter.updatePresetIfNeeded(drawHeight, size.height, size.width, isDark)
+                    painter.updateColors(currentColors)
+                    painter.updateAnimTime(animTime())
+
+                    drawRect(painter.brush, alpha = alpha())
+                }
             }
         }
         content()

--- a/example/shared/src/commonMain/kotlin/component/effect/BgEffectConfig.kt
+++ b/example/shared/src/commonMain/kotlin/component/effect/BgEffectConfig.kt
@@ -7,99 +7,136 @@ internal object BgEffectConfig {
 
     internal class Config(
         val points: FloatArray,
-        val colors: FloatArray,
+        val colors1: FloatArray,
+        val colors2: FloatArray,
+        val colors3: FloatArray,
+        val colorInterpPeriod: Float,
         val lightOffset: Float,
         val saturateOffset: Float,
+        val pointOffset: Float,
+        // OS3 Specific
+        val shadowColorMulti: Float = 0.3f,
+        val shadowColorOffset: Float = 0.3f,
+        val shadowNoiseScale: Float = 5.0f,
     )
 
-    /*
-     * PHONE LIGHT
-     */
-    private val PHONE_LIGHT = Config(
-        points = floatArrayOf(
-            0.67f, 0.42f, 1.0f, 0.69f, 0.75f, 1.0f,
-            0.14f, 0.71f, 0.95f, 0.14f, 0.27f, 0.8f,
-        ),
-        colors = floatArrayOf(
-            0.57f, 0.76f, 0.98f, 1.0f,
-            0.98f, 0.85f, 0.68f, 1.0f,
-            0.98f, 0.75f, 0.93f, 1.0f,
-            0.73f, 0.70f, 0.98f, 1.0f,
-        ),
+    // OS2 Data
+
+    private val OS2_PHONE_LIGHT_COLORS = floatArrayOf(
+        0.57f, 0.76f, 0.98f, 1.0f, 0.98f, 0.85f, 0.68f, 1.0f, 0.98f, 0.75f, 0.93f, 1.0f, 0.73f, 0.70f, 0.98f, 1.0f,
+    )
+    private val OS2_PHONE_LIGHT = Config(
+        points = floatArrayOf(0.67f, 0.42f, 1.0f, 0.69f, 0.75f, 1.0f, 0.14f, 0.71f, 0.95f, 0.14f, 0.27f, 0.8f),
+        colors1 = OS2_PHONE_LIGHT_COLORS,
+        colors2 = OS2_PHONE_LIGHT_COLORS,
+        colors3 = OS2_PHONE_LIGHT_COLORS,
+        colorInterpPeriod = 100f,
         lightOffset = 0.1f,
         saturateOffset = 0.2f,
+        pointOffset = 0.1f,
     )
 
-    /*
-     * PHONE DARK
-     */
-    private val PHONE_DARK = Config(
-        points = floatArrayOf(
-            0.63f, 0.50f, 0.88f, 0.69f, 0.75f, 0.80f,
-            0.17f, 0.66f, 0.81f, 0.14f, 0.24f, 0.72f,
-        ),
-        colors = floatArrayOf(
-            0.0f, 0.31f, 0.58f, 1.0f,
-            0.53f, 0.29f, 0.15f, 1.0f,
-            0.46f, 0.06f, 0.27f, 1.0f,
-            0.16f, 0.12f, 0.45f, 1.0f,
-        ),
+    private val OS2_PHONE_DARK_COLORS = floatArrayOf(
+        0.0f, 0.31f, 0.58f, 1.0f, 0.53f, 0.29f, 0.15f, 1.0f, 0.46f, 0.06f, 0.27f, 1.0f, 0.16f, 0.12f, 0.45f, 1.0f,
+    )
+    private val OS2_PHONE_DARK = Config(
+        points = floatArrayOf(0.63f, 0.50f, 0.88f, 0.69f, 0.75f, 0.80f, 0.17f, 0.66f, 0.81f, 0.14f, 0.24f, 0.72f),
+        colors1 = OS2_PHONE_DARK_COLORS,
+        colors2 = OS2_PHONE_DARK_COLORS,
+        colors3 = OS2_PHONE_DARK_COLORS,
+        colorInterpPeriod = 100f,
         lightOffset = -0.1f,
         saturateOffset = 0.2f,
+        pointOffset = 0.1f,
     )
 
-    /*
-     * PAD LIGHT
-     */
-    private val PAD_LIGHT = Config(
-        points = floatArrayOf(
-            0.67f, 0.37f, 0.88f, 0.54f, 0.66f, 1.0f,
-            0.37f, 0.71f, 0.68f, 0.28f, 0.26f, 0.62f,
-        ),
-        colors = floatArrayOf(
-            0.57f, 0.76f, 0.98f, 1.0f,
-            0.98f, 0.85f, 0.68f, 1.0f,
-            0.98f, 0.75f, 0.93f, 0.95f,
-            0.73f, 0.70f, 0.98f, 0.90f,
-        ),
+    private val OS2_PAD_LIGHT_COLORS = floatArrayOf(
+        0.57f, 0.76f, 0.98f, 1.0f, 0.98f, 0.85f, 0.68f, 1.0f, 0.98f, 0.75f, 0.93f, 0.95f, 0.73f, 0.70f, 0.98f, 0.90f,
+    )
+    private val OS2_PAD_LIGHT = Config(
+        points = floatArrayOf(0.67f, 0.37f, 0.88f, 0.54f, 0.66f, 1.0f, 0.37f, 0.71f, 0.68f, 0.28f, 0.26f, 0.62f),
+        colors1 = OS2_PAD_LIGHT_COLORS,
+        colors2 = OS2_PAD_LIGHT_COLORS,
+        colors3 = OS2_PAD_LIGHT_COLORS,
+        colorInterpPeriod = 100f,
         lightOffset = 0.1f,
         saturateOffset = 0f,
+        pointOffset = 0.1f,
     )
 
-    /*
-     * PAD DARK
-     */
-    private val PAD_DARK = Config(
-        points = floatArrayOf(
-            0.55f, 0.42f, 1.0f, 0.56f, 0.75f, 1.0f,
-            0.40f, 0.59f, 0.71f, 0.43f, 0.09f, 0.75f,
-        ),
-        colors = floatArrayOf(
-            0.0f, 0.31f, 0.58f, 1.0f,
-            0.53f, 0.29f, 0.15f, 1.0f,
-            0.46f, 0.06f, 0.27f, 1.0f,
-            0.16f, 0.12f, 0.45f, 1.0f,
-        ),
+    private val OS2_PAD_DARK_COLORS = floatArrayOf(
+        0.0f, 0.31f, 0.58f, 1.0f, 0.53f, 0.29f, 0.15f, 1.0f, 0.46f, 0.06f, 0.27f, 1.0f, 0.16f, 0.12f, 0.45f, 1.0f,
+    )
+    private val OS2_PAD_DARK = Config(
+        points = floatArrayOf(0.55f, 0.42f, 1.0f, 0.56f, 0.75f, 1.0f, 0.40f, 0.59f, 0.71f, 0.43f, 0.09f, 0.75f),
+        colors1 = OS2_PAD_DARK_COLORS,
+        colors2 = OS2_PAD_DARK_COLORS,
+        colors3 = OS2_PAD_DARK_COLORS,
+        colorInterpPeriod = 100f,
         lightOffset = -0.1f,
         saturateOffset = 0.2f,
+        pointOffset = 0.1f,
     )
 
-    /**
-     * 获取当前配置
-     */
+    // OS3 Data
+
+    private val OS3_PHONE_LIGHT = Config(
+        points = floatArrayOf(0.8f, 0.2f, 1.0f, 0.8f, 0.9f, 1.0f, 0.2f, 0.9f, 1.0f, 0.2f, 0.2f, 1.0f),
+        colors1 = floatArrayOf(1.0f, 0.9f, 0.94f, 1.0f, 1.0f, 0.84f, 0.89f, 1.0f, 0.97f, 0.73f, 0.82f, 1.0f, 0.64f, 0.65f, 0.98f, 1.0f),
+        colors2 = floatArrayOf(0.58f, 0.74f, 1.0f, 1.0f, 1.0f, 0.9f, 0.93f, 1.0f, 0.74f, 0.76f, 1.0f, 1.0f, 0.97f, 0.77f, 0.84f, 1.0f),
+        colors3 = floatArrayOf(0.98f, 0.86f, 0.9f, 1.0f, 0.6f, 0.73f, 0.98f, 1.0f, 0.92f, 0.93f, 1.0f, 1.0f, 0.56f, 0.69f, 1.0f, 1.0f),
+        colorInterpPeriod = 5.0f,
+        lightOffset = 0.1f,
+        saturateOffset = 0.2f,
+        pointOffset = 0.2f,
+    )
+
+    private val OS3_PHONE_DARK = Config(
+        points = floatArrayOf(0.8f, 0.2f, 1.0f, 0.8f, 0.9f, 1.0f, 0.2f, 0.9f, 1.0f, 0.2f, 0.2f, 1.0f),
+        colors1 = floatArrayOf(0.2f, 0.06f, 0.88f, 0.4f, 0.3f, 0.14f, 0.55f, 0.5f, 0.0f, 0.64f, 0.96f, 0.5f, 0.11f, 0.16f, 0.83f, 0.4f),
+        colors2 = floatArrayOf(0.07f, 0.15f, 0.79f, 0.5f, 0.62f, 0.21f, 0.67f, 0.5f, 0.06f, 0.25f, 0.84f, 0.5f, 0.0f, 0.2f, 0.78f, 0.5f),
+        colors3 = floatArrayOf(0.58f, 0.3f, 0.74f, 0.4f, 0.27f, 0.18f, 0.6f, 0.5f, 0.66f, 0.26f, 0.62f, 0.5f, 0.12f, 0.16f, 0.7f, 0.6f),
+        colorInterpPeriod = 8.0f,
+        lightOffset = 0.0f,
+        saturateOffset = 0.17f,
+        pointOffset = 0.4f,
+    )
+
+    private val OS3_PAD_LIGHT = Config(
+        points = floatArrayOf(0.8f, 0.2f, 1.0f, 0.8f, 0.9f, 1.0f, 0.2f, 0.9f, 1.0f, 0.2f, 0.2f, 1.0f),
+        colors1 = floatArrayOf(0.99f, 0.77f, 0.86f, 1.0f, 0.74f, 0.76f, 1.0f, 1.0f, 0.72f, 0.74f, 1.0f, 1.0f, 0.98f, 0.76f, 0.8f, 1.0f),
+        colors2 = floatArrayOf(0.66f, 0.75f, 1.0f, 1.0f, 1.0f, 0.86f, 0.91f, 1.0f, 0.74f, 0.76f, 1.0f, 1.0f, 0.97f, 0.77f, 0.84f, 1.0f),
+        colors3 = floatArrayOf(0.97f, 0.79f, 0.85f, 1.0f, 0.65f, 0.68f, 0.98f, 1.0f, 0.66f, 0.77f, 1.0f, 1.0f, 0.72f, 0.73f, 0.98f, 1.0f),
+        colorInterpPeriod = 7.0f,
+        lightOffset = 0.1f,
+        saturateOffset = 0.2f,
+        pointOffset = 0.2f,
+    )
+
+    private val OS3_PAD_DARK = Config(
+        points = floatArrayOf(0.8f, 0.2f, 1.0f, 0.8f, 0.9f, 1.0f, 0.2f, 0.9f, 1.0f, 0.2f, 0.2f, 1.0f),
+        colors1 = floatArrayOf(0.66f, 0.26f, 0.62f, 0.4f, 0.06f, 0.25f, 0.84f, 0.5f, 0.0f, 0.64f, 0.96f, 0.5f, 0.14f, 0.18f, 0.55f, 0.5f),
+        colors2 = floatArrayOf(0.07f, 0.15f, 0.79f, 0.5f, 0.11f, 0.16f, 0.83f, 0.5f, 0.06f, 0.25f, 0.84f, 0.5f, 0.66f, 0.26f, 0.62f, 0.5f),
+        colors3 = floatArrayOf(0.58f, 0.3f, 0.74f, 0.5f, 0.11f, 0.16f, 0.83f, 0.5f, 0.66f, 0.26f, 0.62f, 0.5f, 0.27f, 0.18f, 0.6f, 0.6f),
+        colorInterpPeriod = 7.0f,
+        lightOffset = 0.0f,
+        saturateOffset = 0.0f,
+        pointOffset = 0.2f,
+    )
+
     internal fun get(
         deviceType: DeviceType,
         isDark: Boolean,
-    ): Config = when (deviceType) {
-        DeviceType.PHONE if !isDark ->
-            PHONE_LIGHT
-
-        DeviceType.PHONE if isDark ->
-            PHONE_DARK
-
-        DeviceType.PAD if !isDark ->
-            PAD_LIGHT
-
-        else -> PAD_DARK
+        isOs3: Boolean,
+    ): Config = if (!isOs3) {
+        when (deviceType) {
+            DeviceType.PHONE -> if (!isDark) OS2_PHONE_LIGHT else OS2_PHONE_DARK
+            DeviceType.PAD -> if (!isDark) OS2_PAD_LIGHT else OS2_PAD_DARK
+        }
+    } else {
+        when (deviceType) {
+            DeviceType.PHONE -> if (!isDark) OS3_PHONE_LIGHT else OS3_PHONE_DARK
+            DeviceType.PAD -> if (!isDark) OS3_PAD_LIGHT else OS3_PAD_DARK
+        }
     }
 }

--- a/example/shared/src/commonMain/kotlin/component/effect/BgEffectPainter.kt
+++ b/example/shared/src/commonMain/kotlin/component/effect/BgEffectPainter.kt
@@ -3,15 +3,22 @@
 
 package component.effect
 
+import androidx.compose.ui.graphics.Brush
 import top.yukonga.miuix.kmp.blur.RuntimeShader
+import top.yukonga.miuix.kmp.blur.asBrush
 
-class BgEffectPainter {
+class BgEffectPainter(
+    private val isOs3: Boolean = true,
+) {
 
     val runtimeShader by lazy {
-        RuntimeShader(OS2_BG_FRAG).also {
+        val shaderCode = if (isOs3) OS3_BG_FRAG else OS2_BG_FRAG
+        RuntimeShader(shaderCode).also {
             initStaticUniforms(it)
         }
     }
+
+    val brush: Brush by lazy { runtimeShader.asBrush() }
 
     private val resolution = FloatArray(2)
     private val bound = FloatArray(4)
@@ -29,51 +36,44 @@ class BgEffectPainter {
         private const val U_TRANSLATE_Y = 0f
         private const val U_ALPHA_MULTI = 1f
         private const val U_NOISE_SCALE = 1.5f
-        private const val U_POINT_OFFSET = 0.1f
         private const val U_POINT_RADIUS_MULTI = 1f
+        private const val U_ALPHA_OFFSET = 0.1f
+        private const val U_SHADOW_OFFSET = 0.01f
     }
 
     private fun initStaticUniforms(shader: RuntimeShader) {
         shader.setFloatUniform("uTranslateY", U_TRANSLATE_Y)
         shader.setFloatUniform("uNoiseScale", U_NOISE_SCALE)
-        shader.setFloatUniform("uPointOffset", U_POINT_OFFSET)
         shader.setFloatUniform("uPointRadiusMulti", U_POINT_RADIUS_MULTI)
         shader.setFloatUniform("uAlphaMulti", U_ALPHA_MULTI)
+
+        if (isOs3) {
+            shader.setFloatUniform("uAlphaOffset", U_ALPHA_OFFSET)
+            shader.setFloatUniform("uShadowOffset", U_SHADOW_OFFSET)
+        }
     }
 
     fun setDeviceType(type: DeviceType) {
         if (deviceType == type) return
-
         deviceType = type
         presetApplied = false
     }
 
     fun updateResolution(width: Float, height: Float) {
-        if (
-            resolution[0] == width &&
-            resolution[1] == height
-        ) {
-            return
-        }
-
+        if (resolution[0] == width && resolution[1] == height) return
         resolution[0] = width
         resolution[1] = height
-
-        runtimeShader.setFloatUniform(
-            "uResolution",
-            resolution,
-        )
+        runtimeShader.setFloatUniform("uResolution", resolution)
     }
 
     fun updateAnimTime(time: Float) {
         if (animTime == time) return
-
         animTime = time
+        runtimeShader.setFloatUniform("uAnimTime", animTime)
+    }
 
-        runtimeShader.setFloatUniform(
-            "uAnimTime",
-            animTime,
-        )
+    fun updateColors(colors: FloatArray) {
+        runtimeShader.setFloatUniform("uColors", colors)
     }
 
     fun updatePresetIfNeeded(
@@ -82,20 +82,9 @@ class BgEffectPainter {
         width: Float,
         isDark: Boolean,
     ) {
-        if (
-            presetApplied &&
-            isDarkCached == isDark &&
-            deviceTypeCached == deviceType
-        ) {
-            return
-        }
+        if (presetApplied && isDarkCached == isDark && deviceTypeCached == deviceType) return
 
-        updateBound(
-            logoHeight,
-            height,
-            width,
-        )
-
+        updateBound(logoHeight, height, width)
         applyPreset(isDark)
 
         isDarkCached = isDark
@@ -104,32 +93,19 @@ class BgEffectPainter {
     }
 
     private fun applyPreset(isDark: Boolean) {
-        val preset = BgEffectConfig.get(deviceType, isDark)
+        val preset = BgEffectConfig.get(deviceType, isDark, isOs3)
 
-        runtimeShader.setFloatUniform(
-            "uPoints",
-            preset.points,
-        )
+        runtimeShader.setFloatUniform("uPoints", preset.points)
+        runtimeShader.setFloatUniform("uPointOffset", preset.pointOffset)
+        runtimeShader.setFloatUniform("uLightOffset", preset.lightOffset)
+        runtimeShader.setFloatUniform("uSaturateOffset", preset.saturateOffset)
+        runtimeShader.setFloatUniform("uBound", bound)
 
-        runtimeShader.setFloatUniform(
-            "uColors",
-            preset.colors,
-        )
-
-        runtimeShader.setFloatUniform(
-            "uLightOffset",
-            preset.lightOffset,
-        )
-
-        runtimeShader.setFloatUniform(
-            "uSaturateOffset",
-            preset.saturateOffset,
-        )
-
-        runtimeShader.setFloatUniform(
-            "uBound",
-            bound,
-        )
+        if (isOs3) {
+            runtimeShader.setFloatUniform("uShadowColorMulti", preset.shadowColorMulti)
+            runtimeShader.setFloatUniform("uShadowColorOffset", preset.shadowColorOffset)
+            runtimeShader.setFloatUniform("uShadowNoiseScale", preset.shadowNoiseScale)
+        }
     }
 
     private fun updateBound(

--- a/example/shared/src/commonMain/kotlin/component/effect/OS3BgFrag.kt
+++ b/example/shared/src/commonMain/kotlin/component/effect/OS3BgFrag.kt
@@ -1,0 +1,143 @@
+// Copyright 2026, compose-miuix-ui contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package component.effect
+
+const val OS3_BG_FRAG = """
+    uniform vec2 uResolution;
+    uniform shader uTex;
+    uniform shader uTexBitmap;
+    uniform vec2 uTexWH;
+
+    uniform float uAnimTime;
+    uniform vec4 uBound;
+    uniform float uTranslateY;
+    uniform vec3 uPoints[4];
+    uniform vec4 uColors[4];
+    uniform float uAlphaMulti;
+    uniform float uNoiseScale;
+    uniform float uPointOffset;
+    uniform float uPointRadiusMulti;
+    uniform float uSaturateOffset;
+    uniform float uLightOffset;
+    uniform float uAlphaOffset;
+    uniform float uShadowColorMulti;
+    uniform float uShadowColorOffset;
+    uniform float uShadowNoiseScale;
+    uniform float uShadowOffset;
+
+    vec3 hsl2rgb(in vec3 c) {
+        vec3 rgb = clamp(abs(mod(c.x*6.0+vec3(0.0, 4.0, 2.0), 6.0)-3.0)-1.0, 0.0, 1.0);
+        return c.z + c.y * (rgb-0.5)*(1.0-abs(2.0*c.z-1.0));
+    }
+
+    vec3 HueShift (in vec3 Color, in float Shift) {
+        vec3 P = vec3(0.55735)*dot(vec3(0.55735), Color);
+        vec3 U = Color-P;
+        vec3 V = cross(vec3(0.55735), U);
+        Color = U*cos(Shift*6.2832) + V*sin(Shift*6.2832) + P;
+        return vec3(Color);
+    }
+
+    vec3 rgb2hsl(in vec3 c){
+        float h = 0.0; float s = 0.0; float l = 0.0;
+        float r = c.r; float g = c.g; float b = c.b;
+        float cMin = min(r, min(g, b));
+        float cMax = max(r, max(g, b));
+        l = (cMax + cMin) / 2.0;
+        if (cMax > cMin) {
+            float cDelta = cMax - cMin;
+            s = l < .0 ? cDelta / (cMax + cMin) : cDelta / (2.0 - (cMax + cMin));
+            if (r == cMax) h = (g - b) / cDelta;
+            else if (g == cMax) h = 2.0 + (b - r) / cDelta;
+            else h = 4.0 + (r - g) / cDelta;
+            if (h < 0.0) h += 6.0;
+            h = h / 6.0;
+        }
+        return vec3(h, s, l);
+    }
+
+    vec3 rgb2hsv(vec3 c) {
+        vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+        vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+        vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+        float d = q.x - min(q.w, q.y);
+        float e = 1.0e-10;
+        return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+    }
+
+    vec3 hsv2rgb(vec3 c) {
+        vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+        vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+        return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+    }
+
+    float hash(vec2 p) {
+        vec3 p3 = fract(vec3(p.xyx) * 0.13);
+        p3 += dot(p3, p3.yzx + 3.333);
+        return fract((p3.x + p3.y) * p3.z);
+    }
+
+    float perlin(vec2 x) {
+        vec2 i = floor(x); vec2 f = fract(x);
+        float a = hash(i); float b = hash(i + vec2(1.0, 0.0));
+        float c = hash(i + vec2(0.0, 1.0)); float d = hash(i + vec2(1.0, 1.0));
+        vec2 u = f * f * (3.0 - 2.0 * f);
+        return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+    }
+
+    float gradientNoise(in vec2 uv) {
+        return fract(52.9829189 * fract(dot(uv, vec2(0.06711056, 0.00583715))));
+    }
+
+    vec4 main(vec2 fragCoord){
+        vec2 vUv = fragCoord/uResolution;
+        vUv.y = 1.0-vUv.y;
+        vec2 uv = vUv;
+        uv -= vec2(0., uTranslateY);
+        uv.xy -= uBound.xy;
+        uv.xy /= uBound.zw;
+
+        vec3 hsv;
+        vec4 color = vec4(0.0);
+        float noiseValue = perlin(vUv * uNoiseScale + vec2(-uAnimTime, -uAnimTime));
+
+        for (int i = 0; i < 4; i++){
+            vec4 pointColor = uColors[i];
+            pointColor.rgb *= pointColor.a;
+            vec2 point = uPoints[i].xy;
+            float rad = uPoints[i].z * uPointRadiusMulti;
+
+            point.x += sin(uAnimTime + point.y) * uPointOffset;
+            point.y += cos(uAnimTime + point.x) * uPointOffset;
+
+            float d = distance(uv, point);
+            float pct = smoothstep(rad, 0., d);
+
+            color.rgb = mix(color.rgb, pointColor.rgb, pct);
+            color.a = mix(color.a, pointColor.a, pct);
+        }
+
+        float oppositeNoise = smoothstep(0., 1., noiseValue);
+        color.rgb /= color.a;
+        hsv = rgb2hsv(color.rgb);
+        hsv.y = mix(hsv.y, 0.0, oppositeNoise * uSaturateOffset);
+        color.rgb = hsv2rgb(hsv);
+        color.rgb += oppositeNoise * uLightOffset;
+
+        color.a = clamp(color.a, 0., 1.);
+        color.a *= uAlphaMulti;
+
+        vec4 uiColor = uTex.eval(vec2(vUv.x, 1.0 - vUv.y)*uResolution);
+        vec4 fragColor;
+
+        if (uiColor.a < 0.01) {
+            fragColor = color;
+        } else {
+            fragColor = uiColor;
+        }
+
+        color += (1.0 / 255.0) * gradientNoise(fragCoord.xy) - (0.5 / 255.0);
+        return vec4(color.rgb*color.a, color.a);
+    }
+"""


### PR DESCRIPTION
This change introduces the OS3 background effect variant, including:
- Added `OS3_BG_FRAG` shader and updated `BgEffectPainter` to support it.
- Expanded `BgEffectConfig` with OS3-specific data, colors, and interpolation parameters.
- Updated `BgEffectBackground` to handle color interpolation and stage-based animations.
- Added a dropdown menu in the `AboutPage` to switch between OS2 and OS3 background effect variants.
- Refactored `AboutPage` layout to use `LazyColumn` items avoid cutoff of effect settings.