### PR TITLE
example: Implement `rememberNavBackStack` and navigation serialization

### DIFF
--- a/example/shared/build.gradle.kts
+++ b/example/shared/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.kotlinSerialization)
 }
 
 val generatedSrcDir: Provider<Directory> = layout.buildDirectory.dir("generated/miuix-example")
@@ -66,6 +67,7 @@ kotlin {
                 implementation(libs.androidx.navigation3.runtime)
                 implementation(libs.aboutlibraries.core)
                 implementation(libs.jetbrains.androidx.navigationevent)
+                implementation(libs.kotlinx.serialization.core)
             }
         }
 

--- a/example/shared/src/commonMain/kotlin/AppContent.kt
+++ b/example/shared/src/commonMain/kotlin/AppContent.kt
@@ -44,7 +44,6 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -62,16 +61,21 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberDecoratedNavEntries
+import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.ui.NavDisplayTransitionEffects
 import androidx.navigationevent.NavigationEventInfo
 import androidx.navigationevent.compose.NavigationBackHandler
 import androidx.navigationevent.compose.rememberNavigationEventState
+import androidx.savedstate.serialization.SavedStateConfiguration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
 import navigation3.Navigator
 import navigation3.Route
 import top.yukonga.miuix.kmp.basic.FabPosition
@@ -154,7 +158,28 @@ fun AppContent(
         mainPagerState.syncPage()
     }
 
-    val backStack = remember { mutableStateListOf<NavKey>().apply { add(Route.Main) } }
+    val serializersModule = remember {
+        SerializersModule {
+            polymorphic(NavKey::class) {
+                subclass(Route.Main::class)
+                subclass(Route.About::class)
+                subclass(Route.License::class)
+                subclass(Route.NavTest::class)
+                subclass(Route.MultiScaffoldTest::class)
+            }
+        }
+    }
+
+    val savedStateConfig = remember(serializersModule) {
+        SavedStateConfiguration {
+            this.serializersModule = serializersModule
+        }
+    }
+
+    val backStack = rememberNavBackStack(
+        configuration = savedStateConfig,
+        Route.Main
+    )
     val navigator = remember { Navigator(backStack) }
 
     val navigationItems = remember {

--- a/example/shared/src/commonMain/kotlin/AppContent.kt
+++ b/example/shared/src/commonMain/kotlin/AppContent.kt
@@ -178,7 +178,7 @@ fun AppContent(
 
     val backStack = rememberNavBackStack(
         configuration = savedStateConfig,
-        Route.Main
+        Route.Main,
     )
     val navigator = remember { Navigator(backStack) }
 

--- a/example/shared/src/commonMain/kotlin/navigation3/Route.kt
+++ b/example/shared/src/commonMain/kotlin/navigation3/Route.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.Serializable
  * Type-safe navigation keys for Navigation3.
  * Each destination is a NavKey (data object/data class) and can be saved/restored in the back stack.
  */
+@Serializable
 sealed interface Route : NavKey {
     @Serializable
     data object Main : Route

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "9.1.1"
 kotlin = "2.3.20"
+kotlinx-serialization = "1.11.0"
 
 about-libraries = "14.0.1"
 androidx-activity = "1.13.0"
@@ -26,6 +27,7 @@ profileinstaller = "1.4.1"
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 spotless-plugin-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 
 aboutlibraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "about-libraries" }
 androidx-activity = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
@@ -49,6 +51,7 @@ androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profi
 androidApplication = { id = "com.android.application" } # AGP
 androidKotlinMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library" } # AGP
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform" } # KGP
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
 aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "about-libraries" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
Update the navigation implementation to use `rememberNavBackStack` with a `SavedStateConfiguration`. This enables proper state restoration for navigation keys by providing a `SerializersModule` that handles polymorphic `Route` types.

- Add `kotlinx-serialization` plugin and dependency.
- Mark `Route` and its subclasses as `@Serializable`.
- Configure `SerializersModule` to support `NavKey` polymorphism.
- Replace manual `mutableStateListOf` backstack with `rememberNavBackStack`.