### PR TITLE
feat(preference): add SliderPreference and RangeSliderPreference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ docs/public/compose
 docs/public/icons
 miuix-ui/**/generated/baselineProfiles/**
 example/ios/iosApp/Generated.xcconfig
+/build-plugins/bin
+/docs/iconGen/bin

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -52,6 +52,8 @@ The Scaffold component provides a suitable container for cross-platform popup wi
 | [SwitchPreference](../components/switchpreference)             | Switch component based on BasicComponent                                                 | Setting switches, feature enabling     |
 | [CheckboxPreference](../components/checkboxpreference)         | Checkbox component based on BasicComponent                                               | Multiple selection, terms agreement    |
 | [RadioButtonPreference](../components/radiobuttonpreference)   | Radio button component based on BasicComponent                                           | Exclusive choices, option selection    |
+| [SliderPreference](../components/sliderpreference)             | Slider component based on BasicComponent                                                 | Value adjustment, volume/brightness    |
+| [RangeSliderPreference](../components/rangesliderpreference)   | Range slider component based on BasicComponent                                           | Range selection, price filter          |
 | [OverlayListPopup](../components/overlaylistpopup)             | List popup component based on BasicComponent (uses MiuixPopupUtils; requires `Scaffold`) | Option selection, feature list         |
 | [OverlayCascadingListPopup](../components/overlaycascadinglistpopup) | Two-level cascading list popup (uses MiuixPopupUtils; requires `Scaffold`)               | Submenus, grouped action panels        |
 | [OverlayDropdownPreference](../components/overlaydropdownpreference) | Dropdown selector based on BasicComponent (uses MiuixPopupUtils; requires `Scaffold`)    | Option selection, feature list         |

--- a/docs/components/rangesliderpreference.md
+++ b/docs/components/rangesliderpreference.md
@@ -1,0 +1,140 @@
+# RangeSliderPreference
+
+`RangeSliderPreference` is a preference component in Miuix that combines a title/summary with a range slider control. The range slider is placed in the bottom action area of the `BasicComponent`, making it ideal for settings screens where users need to select a range of values such as price filters, frequency bands, or dual-threshold controls.
+
+## Import
+
+```kotlin
+import top.yukonga.miuix.kmp.preference.RangeSliderPreference
+```
+
+## Basic Usage
+
+```kotlin
+var rangeValue by remember { mutableStateOf(0.2f..0.8f) }
+
+RangeSliderPreference(
+    value = rangeValue,
+    onValueChange = { rangeValue = it },
+    title = "Range Selection"
+)
+```
+
+## With Summary
+
+```kotlin
+var priceRange by remember { mutableStateOf(100f..500f) }
+
+RangeSliderPreference(
+    value = priceRange,
+    onValueChange = { priceRange = it },
+    title = "Price Range",
+    summary = "$${priceRange.start.roundToInt()} - $${priceRange.endInclusive.roundToInt()}",
+    valueRange = 0f..1000f
+)
+```
+
+## Component States
+
+### Disabled State
+
+```kotlin
+var rangeValue by remember { mutableStateOf(0.3f..0.7f) }
+
+RangeSliderPreference(
+    value = rangeValue,
+    onValueChange = { rangeValue = it },
+    title = "Disabled Range",
+    summary = "This range slider is currently unavailable",
+    enabled = false
+)
+```
+
+## Properties
+
+### RangeSliderPreference Properties
+
+| Property Name         | Type                                        | Description                                                                                                                                                                    | Default Value                      | Required |
+| --------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | -------- |
+| value                 | ClosedFloatingPointRange\<Float\>           | Current values of the range slider. If either value is outside of valueRange, it will be coerced                                                                              | -                                  | Yes      |
+| onValueChange         | (ClosedFloatingPointRange\<Float\>) -> Unit | Lambda in which values should be updated                                                                                                                                       | -                                  | Yes      |
+| title                 | String?                                     | Title of the preference                                                                                                                                                        | null                               | No       |
+| modifier              | Modifier                                    | Modifier applied to the component                                                                                                                                              | Modifier                           | No       |
+| titleColor            | BasicComponentColors                        | Title text color configuration                                                                                                                                                 | BasicComponentDefaults.titleColor() | No       |
+| summary               | String?                                     | Summary description                                                                                                                                                            | null                               | No       |
+| summaryColor          | BasicComponentColors                        | Summary text color configuration                                                                                                                                               | BasicComponentDefaults.summaryColor() | No       |
+| startAction           | @Composable (() -> Unit)?                   | Custom start side content                                                                                                                                                      | null                               | No       |
+| valueText             | String?                                     | Current slider value text displayed in the end area with summary-style formatting. Rendered inside the Row layout with center-vertical alignment and weight                     | null                               | No       |
+| endActions            | @Composable (RowScope.() -> Unit)?          | Custom end side content, rendered after valueText within the same Row                                                                                                          | null                               | No       |
+| bottomAction          | @Composable (() -> Unit)?                   | Custom content at the top of the bottom area, above the range slider                                                                                                           | null                               | No       |
+| onClick               | (() -> Unit)?                               | Callback triggered on click. When non-null, an arrow icon is displayed in the end area                                                                                        | null                               | No       |
+| holdDownState         | Boolean                                     | Whether the component is in the pressed state                                                                                                                                  | false                              | No       |
+| enabled               | Boolean                                     | Whether the preference is enabled                                                                                                                                              | true                               | No       |
+| valueRange            | ClosedFloatingPointRange\<Float\>           | Range of values that range slider values can take. Passed value will be coerced to this range                                                                                  | 0f..1f                             | No       |
+| steps                 | Int                                         | Amount of discrete allowable values. If 0, the slider will behave continuously. Must not be negative                                                                           | 0                                  | No       |
+| onValueChangeFinished | (() -> Unit)?                               | Called when value change has ended                                                                                                                                              | null                               | No       |
+| sliderHeight          | Dp                                          | Height of the range slider                                                                                                                                                     | SliderDefaults.MinHeight           | No       |
+| sliderColors          | SliderColors                                | Color configuration of the range slider                                                                                                                                        | SliderDefaults.sliderColors()      | No       |
+| hapticEffect          | SliderDefaults.SliderHapticEffect           | Type of haptic feedback                                                                                                                                                        | SliderDefaults.DefaultHapticEffect | No       |
+| showKeyPoints         | Boolean                                     | Whether to show key point indicators on the slider. Only works when keyPoints is not null                                                                                      | false                              | No       |
+| keyPoints             | List\<Float\>?                              | Custom key point values to display on the slider. If null, uses step positions from steps parameter. Values should be within valueRange                                        | null                               | No       |
+| magnetThreshold       | Float                                       | Magnetic snap threshold as a fraction (0.0 to 1.0). When slider value is within this distance from a key point, it will snap to that point. Only applies when keyPoints is set | 0.02f                              | No       |
+| insideMargin          | PaddingValues                               | Internal content padding                                                                                                                                                       | BasicComponentDefaults.InsideMargin | No       |
+
+## Advanced Usage
+
+### Price Range Filter
+
+```kotlin
+var priceRange by remember { mutableStateOf(100f..500f) }
+
+RangeSliderPreference(
+    value = priceRange,
+    onValueChange = { priceRange = it },
+    title = "Price Filter",
+    summary = "$${priceRange.start.roundToInt()} - $${priceRange.endInclusive.roundToInt()}",
+    valueRange = 0f..1000f,
+    steps = 99
+)
+```
+
+### With Start Icon
+
+```kotlin
+var frequencyRange by remember { mutableStateOf(20f..20000f) }
+
+RangeSliderPreference(
+    value = frequencyRange,
+    onValueChange = { frequencyRange = it },
+    title = "Frequency Range",
+    summary = "${frequencyRange.start.roundToInt()}Hz - ${frequencyRange.endInclusive.roundToInt()}Hz",
+    startAction = {
+        Icon(
+            imageVector = MiuixIcons.Basic.Audio,
+            contentDescription = "Frequency Icon",
+            tint = MiuixTheme.colorScheme.onBackground,
+            modifier = Modifier.padding(end = 16.dp)
+        )
+    },
+    valueRange = 20f..20000f,
+    showKeyPoints = true,
+    keyPoints = listOf(20f, 100f, 1000f, 5000f, 10000f, 20000f)
+)
+```
+
+### With Custom Key Points
+
+```kotlin
+var range by remember { mutableStateOf(20f..80f) }
+
+RangeSliderPreference(
+    value = range,
+    onValueChange = { range = it },
+    title = "Custom Range",
+    summary = "${range.start.roundToInt()}% - ${range.endInclusive.roundToInt()}%",
+    valueRange = 0f..100f,
+    showKeyPoints = true,
+    keyPoints = listOf(0f, 20f, 40f, 60f, 80f, 100f),
+    magnetThreshold = 0.03f
+)
+```

--- a/docs/components/sliderpreference.md
+++ b/docs/components/sliderpreference.md
@@ -1,0 +1,140 @@
+# SliderPreference
+
+`SliderPreference` is a preference component in Miuix that combines a title/summary with a slider control. The slider is placed in the bottom action area of the `BasicComponent`, making it ideal for settings screens where users need to adjust values such as volume, brightness, or font size.
+
+## Import
+
+```kotlin
+import top.yukonga.miuix.kmp.preference.SliderPreference
+```
+
+## Basic Usage
+
+```kotlin
+var sliderValue by remember { mutableFloatStateOf(0.5f) }
+
+SliderPreference(
+    value = sliderValue,
+    onValueChange = { sliderValue = it },
+    title = "Volume"
+)
+```
+
+## With Summary
+
+```kotlin
+var brightness by remember { mutableFloatStateOf(0.8f) }
+
+SliderPreference(
+    value = brightness,
+    onValueChange = { brightness = it },
+    title = "Brightness",
+    summary = "Adjust screen brightness level"
+)
+```
+
+## Component States
+
+### Disabled State
+
+```kotlin
+var value by remember { mutableFloatStateOf(0.5f) }
+
+SliderPreference(
+    value = value,
+    onValueChange = { value = it },
+    title = "Disabled Slider",
+    summary = "This slider is currently unavailable",
+    enabled = false
+)
+```
+
+## Properties
+
+### SliderPreference Properties
+
+| Property Name         | Type                              | Description                                                                                                                                                                    | Default Value                      | Required |
+| --------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | -------- |
+| value                 | Float                             | Current value of the slider. If outside of valueRange provided, value will be coerced to this range                                                                            | -                                  | Yes      |
+| onValueChange         | (Float) -> Unit                   | Callback when value changes                                                                                                                                                    | -                                  | Yes      |
+| title                 | String?                           | Title of the preference                                                                                                                                                        | null                               | No       |
+| modifier              | Modifier                          | Modifier applied to the component                                                                                                                                              | Modifier                           | No       |
+| titleColor            | BasicComponentColors              | Title text color configuration                                                                                                                                                 | BasicComponentDefaults.titleColor() | No       |
+| summary               | String?                           | Summary description                                                                                                                                                            | null                               | No       |
+| summaryColor          | BasicComponentColors              | Summary text color configuration                                                                                                                                               | BasicComponentDefaults.summaryColor() | No       |
+| startAction           | @Composable (() -> Unit)?         | Custom start side content                                                                                                                                                      | null                               | No       |
+| valueText             | String?                           | Current slider value text displayed in the end area with summary-style formatting. Rendered inside the Row layout with center-vertical alignment and weight                     | null                               | No       |
+| endActions            | @Composable (RowScope.() -> Unit)?| Custom end side content, rendered after valueText within the same Row                                                                                                          | null                               | No       |
+| bottomAction          | @Composable (() -> Unit)?         | Custom content at the top of the bottom area, above the slider                                                                                                                 | null                               | No       |
+| onClick               | (() -> Unit)?                     | Callback triggered on click. When non-null, an arrow icon is displayed in the end area                                                                                        | null                               | No       |
+| holdDownState         | Boolean                           | Whether the component is in the pressed state                                                                                                                                  | false                              | No       |
+| enabled               | Boolean                           | Whether the preference is enabled                                                                                                                                              | true                               | No       |
+| valueRange            | ClosedFloatingPointRange\<Float\> | Range of values that this slider can take. The passed value will be coerced to this range                                                                                      | 0f..1f                             | No       |
+| steps                 | Int                               | Amount of discrete allowable values. If 0, the slider will behave continuously. Must not be negative                                                                           | 0                                  | No       |
+| onValueChangeFinished | (() -> Unit)?                     | Called when value change has ended                                                                                                                                              | null                               | No       |
+| reverseDirection      | Boolean                           | Controls the direction of slider. When false (default), follows LayoutDirection (L-R in LTR, R-L in RTL). When true, reverses the direction.                                   | false                              | No       |
+| sliderHeight          | Dp                                | Height of the slider                                                                                                                                                           | SliderDefaults.MinHeight           | No       |
+| sliderColors          | SliderColors                      | Color configuration of the slider                                                                                                                                              | SliderDefaults.sliderColors()      | No       |
+| hapticEffect          | SliderDefaults.SliderHapticEffect | Type of haptic feedback                                                                                                                                                        | SliderDefaults.DefaultHapticEffect | No       |
+| showKeyPoints         | Boolean                           | Whether to show key point indicators on the slider. Only works when keyPoints is not null                                                                                      | false                              | No       |
+| keyPoints             | List\<Float\>?                    | Custom key point values to display on the slider. If null, uses step positions from steps parameter. Values should be within valueRange                                        | null                               | No       |
+| magnetThreshold       | Float                             | Magnetic snap threshold as a fraction (0.0 to 1.0). When slider value is within this distance from a key point, it will snap to that point. Only applies when keyPoints is set | 0.02f                              | No       |
+| insideMargin          | PaddingValues                     | Internal content padding                                                                                                                                                       | BasicComponentDefaults.InsideMargin | No       |
+
+## Advanced Usage
+
+### Custom Value Range with Steps
+
+```kotlin
+var temperature by remember { mutableFloatStateOf(25f) }
+
+SliderPreference(
+    value = temperature,
+    onValueChange = { temperature = it },
+    title = "Temperature",
+    summary = "Current: ${temperature.roundToInt()}°C",
+    valueRange = 16f..32f,
+    steps = 15,
+    hapticEffect = SliderDefaults.SliderHapticEffect.Step
+)
+```
+
+### With Start Icon
+
+```kotlin
+var volume by remember { mutableFloatStateOf(0.7f) }
+
+SliderPreference(
+    value = volume,
+    onValueChange = { volume = it },
+    title = "Volume",
+    summary = "${(volume * 100).roundToInt()}%",
+    startAction = {
+        Icon(
+            imageVector = MiuixIcons.Basic.Audio,
+            contentDescription = "Volume Icon",
+            tint = MiuixTheme.colorScheme.onBackground,
+            modifier = Modifier.padding(end = 16.dp)
+        )
+    },
+    valueRange = 0f..1f
+)
+```
+
+### With Custom Key Points
+
+```kotlin
+var fontSize by remember { mutableFloatStateOf(14f) }
+
+SliderPreference(
+    value = fontSize,
+    onValueChange = { fontSize = it },
+    title = "Font Size",
+    summary = "Current: ${fontSize.roundToInt()}sp",
+    valueRange = 10f..24f,
+    showKeyPoints = true,
+    keyPoints = listOf(10f, 12f, 14f, 16f, 18f, 20f, 24f),
+    magnetThreshold = 0.05f,
+    hapticEffect = SliderDefaults.SliderHapticEffect.Step
+)
+```

--- a/docs/zh_CN/components/index.md
+++ b/docs/zh_CN/components/index.md
@@ -52,6 +52,8 @@ Scaffold 组件为跨平台提供了一个合适的弹出窗口的容器。`Over
 | [SwitchPreference](../components/switchpreference)             | 基于 BasicComponent 的开关组件                                                     | 设置项开关、功能启用   |
 | [CheckboxPreference](../components/checkboxpreference)         | 基于 BasicComponent 的复选框组件                                                   | 多项选择、条款同意     |
 | [RadioButtonPreference](../components/radiobuttonpreference)   | 基于 BasicComponent 的单选组件                                                     | 单项选择、选项切换     |
+| [SliderPreference](../components/sliderpreference)             | 基于 BasicComponent 的滑块组件                                                     | 数值调节、音量/亮度    |
+| [RangeSliderPreference](../components/rangesliderpreference)   | 基于 BasicComponent 的范围滑块组件                                                 | 范围选择、价格筛选     |
 | [OverlayListPopup](../components/overlaylistpopup)             | 基于 BasicComponent 的列表弹窗组件（使用 MiuixPopupUtils，需在 `Scaffold` 中使用） | 选项选择、功能列表     |
 | [OverlayCascadingListPopup](../components/overlaycascadinglistpopup) | 二级级联列表弹窗组件（使用 MiuixPopupUtils，需在 `Scaffold` 中使用）               | 子菜单、分组动作面板   |
 | [OverlayDropdownPreference](../components/overlaydropdownpreference) | 基于 BasicComponent 的下拉选择器组件（使用 MiuixPopupUtils，需在 `Scaffold` 中使用） | 选项选择、功能列表     |

--- a/docs/zh_CN/components/rangesliderpreference.md
+++ b/docs/zh_CN/components/rangesliderpreference.md
@@ -1,0 +1,140 @@
+# RangeSliderPreference
+
+`RangeSliderPreference` 是 Miuix 中的范围滑块偏好设置组件，将标题/摘要与范围滑块控件结合在一起。范围滑块放置在 `BasicComponent` 的底部操作区域中，适用于设置界面中需要选择数值范围的场景，如价格筛选、频段选择或双阈值控制。
+
+## 引入
+
+```kotlin
+import top.yukonga.miuix.kmp.preference.RangeSliderPreference
+```
+
+## 基本用法
+
+```kotlin
+var rangeValue by remember { mutableStateOf(0.2f..0.8f) }
+
+RangeSliderPreference(
+    value = rangeValue,
+    onValueChange = { rangeValue = it },
+    title = "范围选择"
+)
+```
+
+## 带摘要
+
+```kotlin
+var priceRange by remember { mutableStateOf(100f..500f) }
+
+RangeSliderPreference(
+    value = priceRange,
+    onValueChange = { priceRange = it },
+    title = "价格范围",
+    summary = "¥${priceRange.start.roundToInt()} - ¥${priceRange.endInclusive.roundToInt()}",
+    valueRange = 0f..1000f
+)
+```
+
+## 组件状态
+
+### 禁用状态
+
+```kotlin
+var rangeValue by remember { mutableStateOf(0.3f..0.7f) }
+
+RangeSliderPreference(
+    value = rangeValue,
+    onValueChange = { rangeValue = it },
+    title = "禁用的范围",
+    summary = "此范围滑块当前不可用",
+    enabled = false
+)
+```
+
+## 属性
+
+### RangeSliderPreference 属性
+
+| 属性名                | 类型                                        | 说明                                                                                                             | 默认值                             | 是否必须 |
+| --------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------- |
+| value                 | ClosedFloatingPointRange\<Float\>           | 范围滑块的当前值。如果任一值超出 valueRange，将被强制限制在范围内                                                | -                                  | 是       |
+| onValueChange         | (ClosedFloatingPointRange\<Float\>) -> Unit | 值变化时的回调函数                                                                                               | -                                  | 是       |
+| title                 | String?                                     | 偏好设置的标题                                                                                                   | null                               | 否       |
+| modifier              | Modifier                                    | 应用于组件的修饰符                                                                                               | Modifier                           | 否       |
+| titleColor            | BasicComponentColors                        | 标题文本的颜色配置                                                                                               | BasicComponentDefaults.titleColor() | 否       |
+| summary               | String?                                     | 摘要说明                                                                                                         | null                               | 否       |
+| summaryColor          | BasicComponentColors                        | 摘要文本的颜色配置                                                                                               | BasicComponentDefaults.summaryColor() | 否       |
+| startAction           | @Composable (() -> Unit)?                   | 左侧自定义内容                                                                                                   | null                               | 否       |
+| valueText             | String?                                     | 当前滑块值文本，以摘要样式显示在末尾区域。在 Row 布局中居中垂直对齐并使用权重                                     | null                               | 否       |
+| endActions            | @Composable (RowScope.() -> Unit)?          | 右侧自定义内容，紧跟 valueText 在同一 Row 中渲染                                                                 | null                               | 否       |
+| bottomAction          | @Composable (() -> Unit)?                   | 底部区域顶部的自定义内容，位于范围滑块上方                                                                       | null                               | 否       |
+| onClick               | (() -> Unit)?                               | 点击时触发的回调。当非 null 时，末尾区域显示箭头图标                                                              | null                               | 否       |
+| holdDownState         | Boolean                                     | 组件是否处于按下状态                                                                                             | false                              | 否       |
+| enabled               | Boolean                                     | 是否启用偏好设置                                                                                                 | true                               | 否       |
+| valueRange            | ClosedFloatingPointRange\<Float\>           | 范围滑块值可以采用的范围。传递的值将被强制限制在此范围内                                                         | 0f..1f                             | 否       |
+| steps                 | Int                                         | 离散值的数量。如果为 0，滑块将连续运行。必须非负                                                                 | 0                                  | 否       |
+| onValueChangeFinished | (() -> Unit)?                               | 值变化结束时调用                                                                                                 | null                               | 否       |
+| sliderHeight          | Dp                                          | 范围滑块的高度                                                                                                   | SliderDefaults.MinHeight           | 否       |
+| sliderColors          | SliderColors                                | 范围滑块的颜色配置                                                                                               | SliderDefaults.sliderColors()      | 否       |
+| hapticEffect          | SliderDefaults.SliderHapticEffect           | 滑块的触感反馈类型                                                                                               | SliderDefaults.DefaultHapticEffect | 否       |
+| showKeyPoints         | Boolean                                     | 是否显示关键点指示器。仅当 keyPoints 不为 null 时有效                                                            | false                              | 否       |
+| keyPoints             | List\<Float\>?                              | 要在滑块上显示的自定义关键点值。如果为 null，则使用 steps 参数的步长位置。值应在 valueRange 范围内               | null                               | 否       |
+| magnetThreshold       | Float                                       | 磁吸对齐阈值，以分数表示 (0.0 到 1.0)。当滑块值与关键点的距离在此阈值内时，将对齐到该点。仅在设置 keyPoints 时生效 | 0.02f                              | 否       |
+| insideMargin          | PaddingValues                               | 组件内部内容的边距                                                                                               | BasicComponentDefaults.InsideMargin | 否       |
+
+## 进阶用法
+
+### 价格范围筛选
+
+```kotlin
+var priceRange by remember { mutableStateOf(100f..500f) }
+
+RangeSliderPreference(
+    value = priceRange,
+    onValueChange = { priceRange = it },
+    title = "价格筛选",
+    summary = "¥${priceRange.start.roundToInt()} - ¥${priceRange.endInclusive.roundToInt()}",
+    valueRange = 0f..1000f,
+    steps = 99
+)
+```
+
+### 带左侧图标
+
+```kotlin
+var frequencyRange by remember { mutableStateOf(20f..20000f) }
+
+RangeSliderPreference(
+    value = frequencyRange,
+    onValueChange = { frequencyRange = it },
+    title = "频率范围",
+    summary = "${frequencyRange.start.roundToInt()}Hz - ${frequencyRange.endInclusive.roundToInt()}Hz",
+    startAction = {
+        Icon(
+            imageVector = MiuixIcons.Basic.Audio,
+            contentDescription = "频率图标",
+            tint = MiuixTheme.colorScheme.onBackground,
+            modifier = Modifier.padding(end = 16.dp)
+        )
+    },
+    valueRange = 20f..20000f,
+    showKeyPoints = true,
+    keyPoints = listOf(20f, 100f, 1000f, 5000f, 10000f, 20000f)
+)
+```
+
+### 自定义关键点
+
+```kotlin
+var range by remember { mutableStateOf(20f..80f) }
+
+RangeSliderPreference(
+    value = range,
+    onValueChange = { range = it },
+    title = "自定义范围",
+    summary = "${range.start.roundToInt()}% - ${range.endInclusive.roundToInt()}%",
+    valueRange = 0f..100f,
+    showKeyPoints = true,
+    keyPoints = listOf(0f, 20f, 40f, 60f, 80f, 100f),
+    magnetThreshold = 0.03f
+)
+```

--- a/docs/zh_CN/components/sliderpreference.md
+++ b/docs/zh_CN/components/sliderpreference.md
@@ -1,0 +1,140 @@
+# SliderPreference
+
+`SliderPreference` 是 Miuix 中的滑块偏好设置组件，将标题/摘要与滑块控件结合在一起。滑块放置在 `BasicComponent` 的底部操作区域中，适用于设置界面中需要调整数值的场景，如音量、亮度或字体大小控制。
+
+## 引入
+
+```kotlin
+import top.yukonga.miuix.kmp.preference.SliderPreference
+```
+
+## 基本用法
+
+```kotlin
+var sliderValue by remember { mutableFloatStateOf(0.5f) }
+
+SliderPreference(
+    value = sliderValue,
+    onValueChange = { sliderValue = it },
+    title = "音量"
+)
+```
+
+## 带摘要
+
+```kotlin
+var brightness by remember { mutableFloatStateOf(0.8f) }
+
+SliderPreference(
+    value = brightness,
+    onValueChange = { brightness = it },
+    title = "亮度",
+    summary = "调整屏幕亮度级别"
+)
+```
+
+## 组件状态
+
+### 禁用状态
+
+```kotlin
+var value by remember { mutableFloatStateOf(0.5f) }
+
+SliderPreference(
+    value = value,
+    onValueChange = { value = it },
+    title = "禁用的滑块",
+    summary = "此滑块当前不可用",
+    enabled = false
+)
+```
+
+## 属性
+
+### SliderPreference 属性
+
+| 属性名                | 类型                              | 说明                                                                                                             | 默认值                             | 是否必须 |
+| --------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------- |
+| value                 | Float                             | 当前滑块的值。如果超出 valueRange，值将被强制限制在该范围内                                                      | -                                  | 是       |
+| onValueChange         | (Float) -> Unit                   | 值变化时的回调函数                                                                                               | -                                  | 是       |
+| title                 | String?                           | 偏好设置的标题                                                                                                   | null                               | 否       |
+| modifier              | Modifier                          | 应用于组件的修饰符                                                                                               | Modifier                           | 否       |
+| titleColor            | BasicComponentColors              | 标题文本的颜色配置                                                                                               | BasicComponentDefaults.titleColor() | 否       |
+| summary               | String?                           | 摘要说明                                                                                                         | null                               | 否       |
+| summaryColor          | BasicComponentColors              | 摘要文本的颜色配置                                                                                               | BasicComponentDefaults.summaryColor() | 否       |
+| startAction           | @Composable (() -> Unit)?         | 左侧自定义内容                                                                                                   | null                               | 否       |
+| valueText             | String?                           | 当前滑块值文本，以摘要样式显示在末尾区域。在 Row 布局中居中垂直对齐并使用权重                                     | null                               | 否       |
+| endActions            | @Composable (RowScope.() -> Unit)?| 右侧自定义内容，紧跟 valueText 在同一 Row 中渲染                                                                 | null                               | 否       |
+| bottomAction          | @Composable (() -> Unit)?         | 底部区域顶部的自定义内容，位于滑块上方                                                                           | null                               | 否       |
+| onClick               | (() -> Unit)?                     | 点击时触发的回调。当非 null 时，末尾区域显示箭头图标                                                              | null                               | 否       |
+| holdDownState         | Boolean                           | 组件是否处于按下状态                                                                                             | false                              | 否       |
+| enabled               | Boolean                           | 是否启用偏好设置                                                                                                 | true                               | 否       |
+| valueRange            | ClosedFloatingPointRange\<Float\> | 滑块可以采用的值范围。传递的值将被强制限制在此范围内                                                             | 0f..1f                             | 否       |
+| steps                 | Int                               | 离散值的数量。如果为 0，滑块将连续运行。必须非负                                                                 | 0                                  | 否       |
+| onValueChangeFinished | (() -> Unit)?                     | 值变化结束时调用                                                                                                 | null                               | 否       |
+| reverseDirection      | Boolean                           | 控制滑块的方向。默认 false，方向跟随 LayoutDirection (LTR 时从左到右，RTL 时从右到左)。为 true 时反转方向。       | false                              | 否       |
+| sliderHeight          | Dp                                | 滑块的高度                                                                                                       | SliderDefaults.MinHeight           | 否       |
+| sliderColors          | SliderColors                      | 滑块的颜色配置                                                                                                   | SliderDefaults.sliderColors()      | 否       |
+| hapticEffect          | SliderDefaults.SliderHapticEffect | 滑块的触感反馈类型                                                                                               | SliderDefaults.DefaultHapticEffect | 否       |
+| showKeyPoints         | Boolean                           | 是否显示关键点指示器。仅当 keyPoints 不为 null 时有效                                                            | false                              | 否       |
+| keyPoints             | List\<Float\>?                    | 要在滑块上显示的自定义关键点值。如果为 null，则使用 steps 参数的步长位置。值应在 valueRange 范围内               | null                               | 否       |
+| magnetThreshold       | Float                             | 磁吸对齐阈值，以分数表示 (0.0 到 1.0)。当滑块值与关键点的距离在此阈值内时，将对齐到该点。仅在设置 keyPoints 时生效 | 0.02f                              | 否       |
+| insideMargin          | PaddingValues                     | 组件内部内容的边距                                                                                               | BasicComponentDefaults.InsideMargin | 否       |
+
+## 进阶用法
+
+### 自定义数值范围与步长
+
+```kotlin
+var temperature by remember { mutableFloatStateOf(25f) }
+
+SliderPreference(
+    value = temperature,
+    onValueChange = { temperature = it },
+    title = "温度",
+    summary = "当前: ${temperature.roundToInt()}°C",
+    valueRange = 16f..32f,
+    steps = 15,
+    hapticEffect = SliderDefaults.SliderHapticEffect.Step
+)
+```
+
+### 带左侧图标
+
+```kotlin
+var volume by remember { mutableFloatStateOf(0.7f) }
+
+SliderPreference(
+    value = volume,
+    onValueChange = { volume = it },
+    title = "音量",
+    summary = "${(volume * 100).roundToInt()}%",
+    startAction = {
+        Icon(
+            imageVector = MiuixIcons.Basic.Audio,
+            contentDescription = "音量图标",
+            tint = MiuixTheme.colorScheme.onBackground,
+            modifier = Modifier.padding(end = 16.dp)
+        )
+    },
+    valueRange = 0f..1f
+)
+```
+
+### 自定义关键点
+
+```kotlin
+var fontSize by remember { mutableFloatStateOf(14f) }
+
+SliderPreference(
+    value = fontSize,
+    onValueChange = { fontSize = it },
+    title = "字体大小",
+    summary = "当前: ${fontSize.roundToInt()}sp",
+    valueRange = 10f..24f,
+    showKeyPoints = true,
+    keyPoints = listOf(10f, 12f, 14f, 16f, 18f, 20f, 24f),
+    magnetThreshold = 0.05f,
+    hapticEffect = SliderDefaults.SliderHapticEffect.Step
+)
+```

--- a/example/shared/src/commonMain/kotlin/component/ArrowSection.kt
+++ b/example/shared/src/commonMain/kotlin/component/ArrowSection.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.unit.dp
 import top.yukonga.miuix.kmp.basic.ButtonDefaults
 import top.yukonga.miuix.kmp.basic.Card
 import top.yukonga.miuix.kmp.basic.Icon
-import top.yukonga.miuix.kmp.basic.Slider
 import top.yukonga.miuix.kmp.basic.SmallTitle
 import top.yukonga.miuix.kmp.basic.Text
 import top.yukonga.miuix.kmp.basic.TextButton
@@ -31,6 +30,7 @@ import top.yukonga.miuix.kmp.icon.MiuixIcons
 import top.yukonga.miuix.kmp.icon.extended.Contacts
 import top.yukonga.miuix.kmp.overlay.OverlayDialog
 import top.yukonga.miuix.kmp.preference.ArrowPreference
+import top.yukonga.miuix.kmp.preference.SliderPreference
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 
 fun LazyListScope.arrowSection() {
@@ -67,26 +67,16 @@ fun LazyListScope.arrowSection() {
                 },
                 onClick = {},
             )
-            ArrowPreference(
-                title = "Arrow + Slider + Dialog (O)",
-                endActions = {
-                    Text(
-                        text = "${(volume * 100).toInt()}%",
-                        fontSize = MiuixTheme.textStyles.body2.fontSize,
-                        color = MiuixTheme.colorScheme.onSurfaceVariantActions,
-                    )
-                },
+            SliderPreference(
+                title = "Volume",
+                valueText = "${(volume * 100).toInt()}%",
+                value = volume,
+                onValueChange = { volume = it },
                 onClick = {
                     showVolumeDialog.value = true
                     volumeDialogHoldDown.value = true
                 },
                 holdDownState = volumeDialogHoldDown.value,
-                bottomAction = {
-                    Slider(
-                        value = volume,
-                        onValueChange = { volume = it },
-                    )
-                },
             )
             ArrowPreference(
                 title = "Disabled Arrow",

--- a/example/shared/src/commonMain/kotlin/component/BlurSection.kt
+++ b/example/shared/src/commonMain/kotlin/component/BlurSection.kt
@@ -34,10 +34,8 @@ import component.effect.BgEffectBackground
 import component.highlight.HighlightConfig
 import component.highlight.rememberContainerHighlight
 import org.jetbrains.compose.resources.painterResource
-import top.yukonga.miuix.kmp.basic.BasicComponent
 import top.yukonga.miuix.kmp.basic.Card
 import top.yukonga.miuix.kmp.basic.HorizontalDivider
-import top.yukonga.miuix.kmp.basic.Slider
 import top.yukonga.miuix.kmp.basic.SmallTitle
 import top.yukonga.miuix.kmp.basic.Text
 import top.yukonga.miuix.kmp.blur.BlendColorEntry
@@ -48,6 +46,7 @@ import top.yukonga.miuix.kmp.blur.layerBackdrop
 import top.yukonga.miuix.kmp.blur.rememberLayerBackdrop
 import top.yukonga.miuix.kmp.blur.textureBlur
 import top.yukonga.miuix.kmp.preference.OverlayDropdownPreference
+import top.yukonga.miuix.kmp.preference.SliderPreference
 import top.yukonga.miuix.kmp.preference.SwitchPreference
 import top.yukonga.miuix.kmp.shared.generated.resources.Res
 import top.yukonga.miuix.kmp.shared.generated.resources.blur_test_bg
@@ -185,66 +184,46 @@ private fun BlurDemo() {
 
             HorizontalDivider(Modifier.fillMaxWidth().padding(horizontal = 16.dp))
 
-            BasicComponent(
+            SliderPreference(
                 title = "Blur Radius",
-                endActions = { ValueText("${blurRadiusX.toInt()}") },
-                bottomAction = {
-                    Slider(
-                        value = blurRadiusX / 200f,
-                        onValueChange = {
-                            blurRadiusX = it * 200f
-                            blurRadiusY = it * 200f
-                        },
-                    )
+                valueText = "${blurRadiusX.toInt()}",
+                value = blurRadiusX / 200f,
+                onValueChange = {
+                    blurRadiusX = it * 200f
+                    blurRadiusY = it * 200f
                 },
                 insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
             )
 
-            BasicComponent(
+            SliderPreference(
                 title = "Noise",
-                endActions = { ValueText("${(noiseCoefficient * 10000).toInt() / 10000f}") },
-                bottomAction = {
-                    Slider(
-                        value = noiseCoefficient / 0.1f,
-                        onValueChange = { noiseCoefficient = it * 0.1f },
-                    )
-                },
+                valueText = "${(noiseCoefficient * 10000).toInt() / 10000f}",
+                value = noiseCoefficient / 0.1f,
+                onValueChange = { noiseCoefficient = it * 0.1f },
                 insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
             )
 
-            BasicComponent(
+            SliderPreference(
                 title = "Brightness",
-                endActions = { ValueText("${(brightness * 100).toInt() / 100f}") },
-                bottomAction = {
-                    Slider(
-                        value = (brightness + 1f) / 2f,
-                        onValueChange = { brightness = it * 2f - 1f },
-                    )
-                },
+                valueText = "${(brightness * 100).toInt() / 100f}",
+                value = (brightness + 1f) / 2f,
+                onValueChange = { brightness = it * 2f - 1f },
                 insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
             )
 
-            BasicComponent(
+            SliderPreference(
                 title = "Contrast",
-                endActions = { ValueText("${(contrast * 100).toInt() / 100f}") },
-                bottomAction = {
-                    Slider(
-                        value = contrast / 3f,
-                        onValueChange = { contrast = it * 3f },
-                    )
-                },
+                valueText = "${(contrast * 100).toInt() / 100f}",
+                value = contrast / 3f,
+                onValueChange = { contrast = it * 3f },
                 insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
             )
 
-            BasicComponent(
+            SliderPreference(
                 title = "Saturation",
-                endActions = { ValueText("${(saturation * 100).toInt() / 100f}") },
-                bottomAction = {
-                    Slider(
-                        value = saturation / 3f,
-                        onValueChange = { saturation = it * 3f },
-                    )
-                },
+                valueText = "${(saturation * 100).toInt() / 100f}",
+                value = saturation / 3f,
+                onValueChange = { saturation = it * 3f },
             )
         }
     }
@@ -360,79 +339,49 @@ private fun ForegroundBlurDemo() {
 
             HorizontalDivider(Modifier.fillMaxWidth().padding(horizontal = 16.dp))
 
-            BasicComponent(
+            SliderPreference(
                 title = "Blur Radius",
-                endActions = { ValueText("${blurRadiusX.toInt()}") },
-                bottomAction = {
-                    Slider(
-                        value = blurRadiusX / 200f,
-                        onValueChange = {
-                            blurRadiusX = it * 200f
-                            blurRadiusY = it * 200f
-                        },
-                    )
+                valueText = "${blurRadiusX.toInt()}",
+                value = blurRadiusX / 200f,
+                onValueChange = {
+                    blurRadiusX = it * 200f
+                    blurRadiusY = it * 200f
                 },
                 insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
             )
 
-            BasicComponent(
+            SliderPreference(
                 title = "Noise",
-                endActions = { ValueText("${(noiseCoefficient * 10000).toInt() / 10000f}") },
-                bottomAction = {
-                    Slider(
-                        value = noiseCoefficient / 0.1f,
-                        onValueChange = { noiseCoefficient = it * 0.1f },
-                    )
-                },
+                valueText = "${(noiseCoefficient * 10000).toInt() / 10000f}",
+                value = noiseCoefficient / 0.1f,
+                onValueChange = { noiseCoefficient = it * 0.1f },
                 insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
             )
 
-            BasicComponent(
+            SliderPreference(
                 title = "Brightness",
-                endActions = { ValueText("${(brightness * 100).toInt() / 100f}") },
-                bottomAction = {
-                    Slider(
-                        value = (brightness + 1f) / 2f,
-                        onValueChange = { brightness = it * 2f - 1f },
-                    )
-                },
+                valueText = "${(brightness * 100).toInt() / 100f}",
+                value = (brightness + 1f) / 2f,
+                onValueChange = { brightness = it * 2f - 1f },
                 insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
             )
 
-            BasicComponent(
+            SliderPreference(
                 title = "Contrast",
-                endActions = { ValueText("${(contrast * 100).toInt() / 100f}") },
-                bottomAction = {
-                    Slider(
-                        value = contrast / 3f,
-                        onValueChange = { contrast = it * 3f },
-                    )
-                },
+                valueText = "${(contrast * 100).toInt() / 100f}",
+                value = contrast / 3f,
+                onValueChange = { contrast = it * 3f },
                 insideMargin = PaddingValues(16.dp, 16.dp, 16.dp, 0.dp),
             )
 
-            BasicComponent(
+            SliderPreference(
                 title = "Saturation",
-                endActions = { ValueText("${(saturation * 100).toInt() / 100f}") },
-                bottomAction = {
-                    Slider(
-                        value = saturation / 3f,
-                        onValueChange = { saturation = it * 3f },
-                    )
-                },
+                valueText = "${(saturation * 100).toInt() / 100f}",
+                value = saturation / 3f,
+                onValueChange = { saturation = it * 3f },
             )
         }
     }
-}
-
-@Suppress("FunctionName")
-@Composable
-private fun ValueText(text: String) {
-    Text(
-        text = text,
-        fontSize = MiuixTheme.textStyles.body2.fontSize,
-        color = MiuixTheme.colorScheme.onSurfaceVariantActions,
-    )
 }
 
 @Composable

--- a/example/shared/src/commonMain/kotlin/component/BottomSheetSection.kt
+++ b/example/shared/src/commonMain/kotlin/component/BottomSheetSection.kt
@@ -26,7 +26,6 @@ import top.yukonga.miuix.kmp.basic.Card
 import top.yukonga.miuix.kmp.basic.CardDefaults
 import top.yukonga.miuix.kmp.basic.Icon
 import top.yukonga.miuix.kmp.basic.IconButton
-import top.yukonga.miuix.kmp.basic.Slider
 import top.yukonga.miuix.kmp.basic.SmallTitle
 import top.yukonga.miuix.kmp.basic.TextField
 import top.yukonga.miuix.kmp.icon.MiuixIcons
@@ -35,6 +34,7 @@ import top.yukonga.miuix.kmp.icon.extended.Ok
 import top.yukonga.miuix.kmp.overlay.OverlayBottomSheet
 import top.yukonga.miuix.kmp.preference.ArrowPreference
 import top.yukonga.miuix.kmp.preference.OverlayDropdownPreference
+import top.yukonga.miuix.kmp.preference.SliderPreference
 import top.yukonga.miuix.kmp.preference.SwitchPreference
 import top.yukonga.miuix.kmp.preference.WindowDropdownPreference
 import top.yukonga.miuix.kmp.theme.LocalDismissState
@@ -176,7 +176,8 @@ private fun SuperBottomSheetDemo(
             }
             item {
                 var sliderValue by remember { mutableFloatStateOf(0.5f) }
-                Slider(
+                SliderPreference(
+                    title = "Slider",
                     value = sliderValue,
                     onValueChange = { sliderValue = it },
                     modifier = Modifier.padding(bottom = 12.dp),
@@ -294,7 +295,8 @@ private fun WindowBottomSheetDemo(
             }
             item {
                 var sliderValue by remember { mutableFloatStateOf(0.5f) }
-                Slider(
+                SliderPreference(
+                    title = "Slider",
                     value = sliderValue,
                     onValueChange = { sliderValue = it },
                     modifier = Modifier.padding(bottom = 12.dp),

--- a/example/shared/src/commonMain/kotlin/component/SliderSection.kt
+++ b/example/shared/src/commonMain/kotlin/component/SliderSection.kt
@@ -21,12 +21,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import top.yukonga.miuix.kmp.basic.Card
-import top.yukonga.miuix.kmp.basic.RangeSlider
-import top.yukonga.miuix.kmp.basic.Slider
 import top.yukonga.miuix.kmp.basic.SliderDefaults
 import top.yukonga.miuix.kmp.basic.SmallTitle
 import top.yukonga.miuix.kmp.basic.Text
 import top.yukonga.miuix.kmp.basic.VerticalSlider
+import top.yukonga.miuix.kmp.preference.RangeSliderPreference
+import top.yukonga.miuix.kmp.preference.SliderPreference
 
 fun LazyListScope.sliderSection() {
     item(key = "slider") {
@@ -37,91 +37,51 @@ fun LazyListScope.sliderSection() {
                 .padding(bottom = 12.dp),
         ) {
             var sliderValue by remember { mutableFloatStateOf(0.3f) }
-            Text(
-                text = "Normal: ${(sliderValue * 100).toInt()}%",
-                fontSize = 14.sp,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(top = 12.dp, bottom = 4.dp),
-            )
-            Slider(
+            SliderPreference(
                 value = sliderValue,
                 onValueChange = { sliderValue = it },
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 12.dp),
+                title = "Normal",
+                valueText = "${(sliderValue * 100).toInt()}%",
             )
             var stepsValue by remember { mutableFloatStateOf(100f) }
-            Text(
-                text = "Steps: ${stepsValue.toInt()}/200",
-                fontSize = 14.sp,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 4.dp),
-            )
-            Slider(
+            SliderPreference(
                 value = stepsValue,
                 onValueChange = { stepsValue = it },
+                title = "Steps",
+                valueText = "${stepsValue.toInt()}/200",
                 valueRange = 0f..200f,
                 steps = 199,
                 hapticEffect = SliderDefaults.SliderHapticEffect.Step,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 12.dp),
             )
             var stepsWithKeyPointsValue by remember { mutableFloatStateOf(5f) }
-            Text(
-                text = "Steps with Key Points: ${stepsWithKeyPointsValue.toInt()}/8",
-                fontSize = 14.sp,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 4.dp),
-            )
-            Slider(
+            SliderPreference(
                 value = stepsWithKeyPointsValue,
                 onValueChange = { stepsWithKeyPointsValue = it },
+                title = "Steps with Key Points",
+                valueText = "${stepsWithKeyPointsValue.toInt()}/8",
                 valueRange = 0f..8f,
                 steps = 7,
                 hapticEffect = SliderDefaults.SliderHapticEffect.Step,
                 showKeyPoints = true,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 12.dp),
             )
             var customKeyPointsValue by remember { mutableFloatStateOf(25f) }
-            Text(
-                text = "Custom Key Points: ${customKeyPointsValue.toInt()}%",
-                fontSize = 14.sp,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 4.dp),
-            )
-            Slider(
+            SliderPreference(
                 value = customKeyPointsValue,
                 onValueChange = { customKeyPointsValue = it },
+                title = "Custom Key Points",
+                valueText = "${customKeyPointsValue.toInt()}%",
                 valueRange = 0f..100f,
                 showKeyPoints = true,
                 hapticEffect = SliderDefaults.SliderHapticEffect.Step,
                 keyPoints = listOf(0f, 25f, 50f, 75f, 100f),
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 12.dp),
             )
             val disabledValue by remember { mutableFloatStateOf(0.7f) }
-            Text(
-                text = "Disabled: ${(disabledValue * 100).toInt()}%",
-                fontSize = 14.sp,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 4.dp),
-            )
-            Slider(
+            SliderPreference(
                 value = disabledValue,
                 onValueChange = {},
+                title = "Disabled",
+                valueText = "${(disabledValue * 100).toInt()}%",
                 enabled = false,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 12.dp),
             )
         }
 
@@ -133,73 +93,41 @@ fun LazyListScope.sliderSection() {
                 .padding(bottom = 12.dp),
         ) {
             var rangeValue by remember { mutableStateOf(0.2f..0.8f) }
-            Text(
-                text = "Range: ${(rangeValue.start * 100).toInt()}% - ${(rangeValue.endInclusive * 100).toInt()}%",
-                fontSize = 14.sp,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(top = 12.dp, bottom = 4.dp),
-            )
-            RangeSlider(
+            RangeSliderPreference(
                 value = rangeValue,
                 onValueChange = { rangeValue = it },
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 12.dp),
+                title = "Range",
+                valueText = "${(rangeValue.start * 100).toInt()}% - ${(rangeValue.endInclusive * 100).toInt()}%",
             )
             var rangeStepsValue by remember { mutableStateOf(2f..8f) }
-            Text(
-                text = "Range with Key Points: ${rangeStepsValue.start.toInt()} - ${rangeStepsValue.endInclusive.toInt()}",
-                fontSize = 14.sp,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 4.dp),
-            )
-            RangeSlider(
+            RangeSliderPreference(
                 value = rangeStepsValue,
                 onValueChange = { rangeStepsValue = it },
+                title = "Range with Key Points",
+                valueText = "${rangeStepsValue.start.toInt()} - ${rangeStepsValue.endInclusive.toInt()}",
                 valueRange = 0f..8f,
                 steps = 7,
                 hapticEffect = SliderDefaults.SliderHapticEffect.Step,
                 showKeyPoints = true,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 12.dp),
             )
             var customRangeValue by remember { mutableStateOf(20f..80f) }
-            Text(
-                text = "Custom Range Points: ${customRangeValue.start.toInt()}% - ${customRangeValue.endInclusive.toInt()}%",
-                fontSize = 14.sp,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 4.dp),
-            )
-            RangeSlider(
+            RangeSliderPreference(
                 value = customRangeValue,
                 onValueChange = { customRangeValue = it },
+                title = "Custom Range Points",
+                valueText = "${customRangeValue.start.toInt()}% - ${customRangeValue.endInclusive.toInt()}%",
                 valueRange = 0f..100f,
                 showKeyPoints = true,
                 hapticEffect = SliderDefaults.SliderHapticEffect.Step,
                 keyPoints = listOf(0f, 20f, 40f, 60f, 80f, 100f),
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 12.dp),
             )
             var disabledRangeValue by remember { mutableStateOf(0.3f..0.7f) }
-            Text(
-                text = "Disabled: ${(disabledRangeValue.start * 100).toInt()}% - ${(disabledRangeValue.endInclusive * 100).toInt()}%",
-                fontSize = 14.sp,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 4.dp),
-            )
-            RangeSlider(
+            RangeSliderPreference(
                 value = disabledRangeValue,
                 onValueChange = {},
+                title = "Disabled",
+                valueText = "${(disabledRangeValue.start * 100).toInt()}% - ${(disabledRangeValue.endInclusive * 100).toInt()}%",
                 enabled = false,
-                modifier = Modifier
-                    .padding(horizontal = 12.dp)
-                    .padding(bottom = 12.dp),
             )
         }
 

--- a/miuix-preference/src/commonMain/kotlin/top/yukonga/miuix/kmp/preference/SliderPreference.kt
+++ b/miuix-preference/src/commonMain/kotlin/top/yukonga/miuix/kmp/preference/SliderPreference.kt
@@ -1,0 +1,321 @@
+// Copyright 2025, compose-miuix-ui contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package top.yukonga.miuix.kmp.preference
+
+import androidx.annotation.IntRange
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.NonRestartableComposable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import top.yukonga.miuix.kmp.basic.BasicComponent
+import top.yukonga.miuix.kmp.basic.BasicComponentColors
+import top.yukonga.miuix.kmp.basic.BasicComponentDefaults
+import top.yukonga.miuix.kmp.basic.RangeSlider
+import top.yukonga.miuix.kmp.basic.Slider
+import top.yukonga.miuix.kmp.basic.SliderColors
+import top.yukonga.miuix.kmp.basic.SliderDefaults
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.icon.MiuixIcons
+import top.yukonga.miuix.kmp.icon.basic.ArrowRight
+import top.yukonga.miuix.kmp.theme.MiuixTheme
+
+/**
+ * A slider preference with a title and a summary.
+ *
+ * The [Slider] is placed in the [BasicComponent]'s bottom action area, displaying below the title and summary text.
+ * This component is typically used in settings screens for value adjustment scenarios such as volume, brightness,
+ * or font size controls.
+ *
+ * @param value The current value of the [Slider]. If outside of [valueRange] provided, value will be coerced to this range.
+ * @param onValueChange The callback to be called when the value changes.
+ * @param modifier The modifier to be applied to the [SliderPreference].
+ * @param title The title of the [SliderPreference].
+ * @param titleColor The color of the title.
+ * @param summary The summary of the [SliderPreference].
+ * @param summaryColor The color of the summary.
+ * @param startAction The [Composable] content on the start side of the [SliderPreference].
+ * @param valueText A nullable [String] representing the current slider value, displayed in the end area with summary-style formatting.
+ *   If null, no value text is shown. The text is rendered inside the existing [Row] layout structure with [Alignment.CenterVertically]
+ *   and [RowScope.weight] applied, consistent with the summary text style.
+ * @param endActions The [Composable] content on the end side of the [SliderPreference], following the [valueText] within the same [Row].
+ * @param bottomAction The [Composable] content at the top of the bottom area, above the [Slider].
+ * @param onClick The callback triggered when the [SliderPreference] is clicked. When non-null, an arrow icon is displayed in the end area.
+ * @param holdDownState Used to determine whether the component is in the pressed state.
+ * @param enabled Whether the [SliderPreference] is enabled.
+ * @param valueRange Range of values that this slider can take. The passed [value] will be coerced to this range.
+ * @param steps If positive, specifies the amount of discrete allowable values between the endpoints of [valueRange].
+ *   For example, a range from 0 to 10 with 4 [steps] allows 4 values evenly distributed between 0 and 10 (i.e., 2, 4, 6, 8).
+ *   If [steps] is 0, the slider will behave continuously and allow any value from the range. Must not be negative.
+ * @param onValueChangeFinished Called when value change has ended. This should not be used to update the slider value
+ *   (use [onValueChange] instead), but rather to know when the user has completed selecting a new value by ending a drag or a click.
+ * @param reverseDirection Controls the direction of this slider. When false (default), slider increases from left to right.
+ *   When true, slider increases from right to left (useful for RTL layouts or custom direction requirements).
+ * @param sliderHeight The height of the [Slider].
+ * @param sliderColors The [SliderColors] of the [Slider].
+ * @param hapticEffect The haptic effect of the [Slider].
+ * @param showKeyPoints Whether to show the key points (step indicators) on the slider. Only works when [keyPoints] is not null.
+ * @param keyPoints Custom key point values to display on the slider. If null, uses step positions from [steps] parameter.
+ *   Values should be within [valueRange]. For example, for a range of 0f..100f, you might specify listOf(0f, 25f, 50f, 75f, 100f).
+ * @param magnetThreshold The magnetic snap threshold as a fraction (0.0 to 1.0). When the slider value is within this
+ *   distance from a key point, it will snap to that point. Default is 0.02 (2%). Only applies when [keyPoints] is set.
+ * @param insideMargin The margin inside the [SliderPreference].
+ */
+@Composable
+@NonRestartableComposable
+fun SliderPreference(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    titleColor: BasicComponentColors = BasicComponentDefaults.titleColor(),
+    summary: String? = null,
+    summaryColor: BasicComponentColors = BasicComponentDefaults.summaryColor(),
+    startAction: @Composable (() -> Unit)? = null,
+    valueText: String? = null,
+    endActions: @Composable (RowScope.() -> Unit)? = null,
+    bottomAction: (@Composable () -> Unit)? = null,
+    onClick: (() -> Unit)? = null,
+    holdDownState: Boolean = false,
+    enabled: Boolean = true,
+    valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
+    @IntRange(from = 0) steps: Int = 0,
+    onValueChangeFinished: (() -> Unit)? = null,
+    reverseDirection: Boolean = false,
+    sliderHeight: Dp = SliderDefaults.MinHeight,
+    sliderColors: SliderColors = SliderDefaults.sliderColors(),
+    hapticEffect: SliderDefaults.SliderHapticEffect = SliderDefaults.DefaultHapticEffect,
+    showKeyPoints: Boolean = false,
+    keyPoints: List<Float>? = null,
+    magnetThreshold: Float = 0.02f,
+    insideMargin: PaddingValues = BasicComponentDefaults.InsideMargin,
+) {
+    val currentOnValueChange by rememberUpdatedState(onValueChange)
+    val currentOnValueChangeFinished by rememberUpdatedState(onValueChangeFinished)
+    val showArrow = onClick != null
+    val showEndArea = valueText != null || endActions != null || showArrow
+
+    BasicComponent(
+        modifier = modifier,
+        insideMargin = insideMargin,
+        title = title,
+        titleColor = titleColor,
+        summary = summary,
+        summaryColor = summaryColor,
+        startAction = startAction,
+        endActions = if (showEndArea) {
+            {
+                Row(
+                    modifier = Modifier
+                        .padding(end = 8.dp)
+                        .align(Alignment.CenterVertically)
+                        .weight(1f, fill = false),
+                ) {
+                    if (valueText != null) {
+                        Text(
+                            text = valueText,
+                            fontSize = MiuixTheme.textStyles.body2.fontSize,
+                            color = if (enabled) summaryColor.color else summaryColor.disabledColor,
+                        )
+                    }
+                    endActions?.invoke(this)
+                }
+                if (showArrow) {
+                    SliderPreferenceArrowIcon(enabled = enabled)
+                }
+            }
+        } else {
+            null
+        },
+        bottomAction = {
+            Column {
+                bottomAction?.invoke()
+                Slider(
+                    value = value,
+                    onValueChange = { currentOnValueChange(it) },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = enabled,
+                    valueRange = valueRange,
+                    steps = steps,
+                    onValueChangeFinished = currentOnValueChangeFinished,
+                    reverseDirection = reverseDirection,
+                    height = sliderHeight,
+                    colors = sliderColors,
+                    hapticEffect = hapticEffect,
+                    showKeyPoints = showKeyPoints,
+                    keyPoints = keyPoints,
+                    magnetThreshold = magnetThreshold,
+                )
+            }
+        },
+        onClick = onClick,
+        holdDownState = holdDownState,
+        enabled = enabled,
+    )
+}
+
+/**
+ * A range slider preference with a title and a summary.
+ *
+ * The [RangeSlider] is placed in the [BasicComponent]'s bottom action area, displaying below the title and summary text.
+ * This component is typically used in settings screens for range selection scenarios such as price filters,
+ * frequency bands, or dual-threshold controls.
+ *
+ * @param value Current values of the [RangeSlider]. If either value is outside of [valueRange] provided, it will be coerced to this range.
+ * @param onValueChange Lambda in which values should be updated.
+ * @param modifier The modifier to be applied to the [RangeSliderPreference].
+ * @param title The title of the [RangeSliderPreference].
+ * @param titleColor The color of the title.
+ * @param summary The summary of the [RangeSliderPreference].
+ * @param summaryColor The color of the summary.
+ * @param startAction The [Composable] content on the start side of the [RangeSliderPreference].
+ * @param valueText A nullable [String] representing the current slider value, displayed in the end area with summary-style formatting.
+ *   If null, no value text is shown. The text is rendered inside the existing [Row] layout structure with [Alignment.CenterVertically]
+ *   and [RowScope.weight] applied, consistent with the summary text style.
+ * @param endActions The [Composable] content on the end side of the [RangeSliderPreference], following the [valueText] within the same [Row].
+ * @param bottomAction The [Composable] content at the top of the bottom area, above the [RangeSlider].
+ * @param onClick The callback triggered when the [RangeSliderPreference] is clicked. When non-null, an arrow icon is displayed in the end area.
+ * @param holdDownState Used to determine whether the component is in the pressed state.
+ * @param enabled Whether the [RangeSliderPreference] is enabled.
+ * @param valueRange Range of values that [RangeSlider] values can take. Passed [value] will be coerced to this range.
+ * @param steps If positive, specifies the amount of discrete allowable values between the endpoints of [valueRange].
+ * @param onValueChangeFinished Lambda to be invoked when value change has ended.
+ * @param sliderHeight The height of the [RangeSlider].
+ * @param sliderColors The [SliderColors] of the [RangeSlider].
+ * @param hapticEffect The haptic effect of the [RangeSlider].
+ * @param showKeyPoints Whether to show the key points (step indicators) on the slider. Only works when [keyPoints] is not null.
+ * @param keyPoints Custom key point values to display on the slider. If null, uses step positions from [steps] parameter.
+ *   Values should be within [valueRange].
+ * @param magnetThreshold The magnetic snap threshold as a fraction (0.0 to 1.0). When the slider value is within this
+ *   distance from a key point, it will snap to that point. Default is 0.02 (2%). Only applies when [keyPoints] is set.
+ * @param insideMargin The margin inside the [RangeSliderPreference].
+ */
+@Composable
+@NonRestartableComposable
+fun RangeSliderPreference(
+    value: ClosedFloatingPointRange<Float>,
+    onValueChange: (ClosedFloatingPointRange<Float>) -> Unit,
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    titleColor: BasicComponentColors = BasicComponentDefaults.titleColor(),
+    summary: String? = null,
+    summaryColor: BasicComponentColors = BasicComponentDefaults.summaryColor(),
+    startAction: @Composable (() -> Unit)? = null,
+    valueText: String? = null,
+    endActions: @Composable (RowScope.() -> Unit)? = null,
+    bottomAction: (@Composable () -> Unit)? = null,
+    onClick: (() -> Unit)? = null,
+    holdDownState: Boolean = false,
+    enabled: Boolean = true,
+    valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
+    @IntRange(from = 0) steps: Int = 0,
+    onValueChangeFinished: (() -> Unit)? = null,
+    sliderHeight: Dp = SliderDefaults.MinHeight,
+    sliderColors: SliderColors = SliderDefaults.sliderColors(),
+    hapticEffect: SliderDefaults.SliderHapticEffect = SliderDefaults.DefaultHapticEffect,
+    showKeyPoints: Boolean = false,
+    keyPoints: List<Float>? = null,
+    magnetThreshold: Float = 0.02f,
+    insideMargin: PaddingValues = BasicComponentDefaults.InsideMargin,
+) {
+    val currentOnValueChange by rememberUpdatedState(onValueChange)
+    val currentOnValueChangeFinished by rememberUpdatedState(onValueChangeFinished)
+    val showArrow = onClick != null
+    val showEndArea = valueText != null || endActions != null || showArrow
+
+    BasicComponent(
+        modifier = modifier,
+        insideMargin = insideMargin,
+        title = title,
+        titleColor = titleColor,
+        summary = summary,
+        summaryColor = summaryColor,
+        startAction = startAction,
+        endActions = if (showEndArea) {
+            {
+                Row(
+                    modifier = Modifier
+                        .padding(end = 8.dp)
+                        .align(Alignment.CenterVertically)
+                        .weight(1f, fill = false),
+                ) {
+                    if (valueText != null) {
+                        Text(
+                            text = valueText,
+                            fontSize = MiuixTheme.textStyles.body2.fontSize,
+                            color = if (enabled) summaryColor.color else summaryColor.disabledColor,
+                        )
+                    }
+                    endActions?.invoke(this)
+                }
+                if (showArrow) {
+                    SliderPreferenceArrowIcon(enabled = enabled)
+                }
+            }
+        } else {
+            null
+        },
+        bottomAction = {
+            Column {
+                bottomAction?.invoke()
+                RangeSlider(
+                    value = value,
+                    onValueChange = { currentOnValueChange(it) },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = enabled,
+                    valueRange = valueRange,
+                    steps = steps,
+                    onValueChangeFinished = currentOnValueChangeFinished,
+                    height = sliderHeight,
+                    colors = sliderColors,
+                    hapticEffect = hapticEffect,
+                    showKeyPoints = showKeyPoints,
+                    keyPoints = keyPoints,
+                    magnetThreshold = magnetThreshold,
+                )
+            }
+        },
+        onClick = onClick,
+        holdDownState = holdDownState,
+        enabled = enabled,
+    )
+}
+
+@Composable
+private fun RowScope.SliderPreferenceArrowIcon(
+    enabled: Boolean,
+) {
+    val actionColors = ArrowPreferenceDefaults.endActionColors()
+    val tintFilter = remember(enabled, actionColors) {
+        ColorFilter.tint(actionColors.color(enabled = enabled))
+    }
+    val layoutDirection = LocalLayoutDirection.current
+    Image(
+        modifier = Modifier
+            .size(width = 10.dp, height = 16.dp)
+            .graphicsLayer {
+                scaleX = if (layoutDirection == LayoutDirection.Rtl) -1f else 1f
+            }
+            .align(Alignment.CenterVertically),
+        imageVector = MiuixIcons.Basic.ArrowRight,
+        contentDescription = null,
+        colorFilter = tintFilter,
+    )
+}

--- a/miuix-preference/src/commonMain/kotlin/top/yukonga/miuix/kmp/preference/SliderPreference.kt
+++ b/miuix-preference/src/commonMain/kotlin/top/yukonga/miuix/kmp/preference/SliderPreference.kt
@@ -132,7 +132,7 @@ fun SliderPreference(
                         Text(
                             text = valueText,
                             fontSize = MiuixTheme.textStyles.body2.fontSize,
-                            color = if (enabled) summaryColor.color else summaryColor.disabledColor,
+                            color = if (enabled) MiuixTheme.colorScheme.onSurfaceVariantActions else MiuixTheme.colorScheme.disabledOnSecondaryVariant,
                         )
                     }
                     endActions?.invoke(this)
@@ -260,7 +260,7 @@ fun RangeSliderPreference(
                         Text(
                             text = valueText,
                             fontSize = MiuixTheme.textStyles.body2.fontSize,
-                            color = if (enabled) summaryColor.color else summaryColor.disabledColor,
+                            color = if (enabled) MiuixTheme.colorScheme.onSurfaceVariantActions else MiuixTheme.colorScheme.disabledOnSecondaryVariant,
                         )
                     }
                     endActions?.invoke(this)


### PR DESCRIPTION
Introduce new preference components for slider-based value adjustments:
- `SliderPreference`: A single-value slider preference.
- `RangeSliderPreference`: A dual-value range slider preference.

Both components integrate with `BasicComponent` and support:
- Title and summary text.
- Custom `valueText` display.
- Customizable `startAction` and `endActions`.
- `onClick` support with arrow icon indicator.
- Integration with existing `Slider` and `RangeSlider` components.

Also updated documentation (English and Chinese) and example usage.