### PR TITLE
example: fix wide-screen layout and navigation rail blur

### DIFF
--- a/example/shared/src/commonMain/kotlin/AboutPage.kt
+++ b/example/shared/src/commonMain/kotlin/AboutPage.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -38,6 +40,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -77,6 +80,7 @@ import top.yukonga.miuix.kmp.theme.MiuixTheme
 import ui.isInDarkTheme
 import utils.BlurredBar
 import utils.pageContentPadding
+import utils.pageHorizontalPadding
 import utils.pageScrollModifiers
 import utils.rememberBlurBackdrop
 import androidx.compose.ui.graphics.BlendMode as ComposeBlendMode
@@ -107,6 +111,7 @@ fun AboutPage(
     }
 
     val backdrop = rememberBlurBackdrop()
+    val layoutDirection = LocalLayoutDirection.current
     // Defer the frame-rate scroll read out of composition: these booleans only flip at the
     // single 1f threshold, so derivedStateOf recomposes the bar on flip rather than every frame.
     val collapsed by remember { derivedStateOf { scrollProgress == 1f } }
@@ -125,6 +130,7 @@ fun AboutPage(
             BlurredBar(backdrop, blurActive) {
                 SmallTopAppBar(
                     title = "About",
+                    modifier = Modifier.pageHorizontalPadding(padding),
                     scrollBehavior = topAppBarScrollBehavior,
                     color = barColor,
                     titleColor = titleColor,
@@ -141,7 +147,9 @@ fun AboutPage(
         Box(modifier = if (backdrop != null) Modifier.layerBackdrop(backdrop) else Modifier) {
             AboutContent(
                 padding = PaddingValues(
+                    start = padding.calculateStartPadding(layoutDirection),
                     top = innerPadding.calculateTopPadding(),
+                    end = padding.calculateEndPadding(layoutDirection),
                     bottom = padding.calculateBottomPadding(),
                 ),
                 topAppBarScrollBehavior = topAppBarScrollBehavior,

--- a/example/shared/src/commonMain/kotlin/AppContent.kt
+++ b/example/shared/src/commonMain/kotlin/AppContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
@@ -26,6 +27,7 @@ import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.captionBarPadding
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.exclude
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.only
@@ -33,6 +35,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -79,7 +82,9 @@ import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
 import navigation3.Navigator
 import navigation3.Route
+import top.yukonga.miuix.kmp.anim.folmeSpring
 import top.yukonga.miuix.kmp.basic.Badge
+import top.yukonga.miuix.kmp.basic.DividerDefaults
 import top.yukonga.miuix.kmp.basic.FabPosition
 import top.yukonga.miuix.kmp.basic.FloatingActionButton
 import top.yukonga.miuix.kmp.basic.FloatingNavigationBar
@@ -93,6 +98,7 @@ import top.yukonga.miuix.kmp.basic.NavigationBarDisplayMode
 import top.yukonga.miuix.kmp.basic.NavigationBarItem
 import top.yukonga.miuix.kmp.basic.NavigationItem
 import top.yukonga.miuix.kmp.basic.NavigationRail
+import top.yukonga.miuix.kmp.basic.NavigationRailDefaults
 import top.yukonga.miuix.kmp.basic.NavigationRailItem
 import top.yukonga.miuix.kmp.basic.NavigationRailValue
 import top.yukonga.miuix.kmp.basic.Scaffold
@@ -120,6 +126,7 @@ import top.yukonga.miuix.kmp.icon.extended.Settings
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 import ui.isInDarkTheme
 import utils.FPSMonitor
+import utils.rememberBlurBackdrop
 import utils.shouldExpandNavigationRail
 import utils.shouldShowSplitPane
 import kotlin.math.abs
@@ -321,6 +328,9 @@ private fun WideScreenContent(
 ) {
     val appState = LocalAppState.current
     val page = mainPagerState.selectedPage
+    val backdrop = rememberBlurBackdrop()
+    val blurActive = backdrop != null
+    val barColor = if (blurActive) Color.Transparent else MiuixTheme.colorScheme.surface
     val expandRail = shouldExpandNavigationRail()
     val railState = rememberNavigationRailState(
         initialValue = if (expandRail) NavigationRailValue.Expanded else NavigationRailValue.Collapsed,
@@ -328,22 +338,19 @@ private fun WideScreenContent(
     LaunchedEffect(expandRail) {
         if (expandRail) railState.expand() else railState.collapse()
     }
-    Row {
-        if (appState.showNavigationBar) {
-            NavigationRail(
-                state = railState,
-            ) {
-                navigationItems.forEachIndexed { index, item ->
-                    NavigationRailItem(
-                        selected = page == index,
-                        onClick = { mainPagerState.animateToPage(index) },
-                        icon = item.icon,
-                        label = item.label,
-                        badge = navigationItemBadge(index, appState.showNavigationBarBadge),
-                    )
-                }
-            }
-        }
+    val railWidth by animateDpAsState(
+        targetValue = if (railState.isExpanded) {
+            NavigationRailDefaults.ExpandedWidth
+        } else {
+            NavigationRailDefaults.MinWidth
+        },
+        animationSpec = folmeSpring(damping = 1f, response = 0.35f),
+        label = "wideNavigationRailWidth",
+    )
+    val railContainerWidth = railWidth + DividerDefaults.Thickness
+    val contentStartPadding = if (appState.showNavigationBar) railContainerWidth else 0.dp
+
+    Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
             modifier = Modifier
                 .fillMaxSize(),
@@ -365,14 +372,64 @@ private fun WideScreenContent(
             },
             floatingToolbarPosition = appState.floatingToolbarPosition.toToolbarPosition(),
         ) { padding ->
-            AppPager(
-                snackbarHostState = snackbarHostState,
-                padding = PaddingValues(top = padding.calculateTopPadding()),
-                pagerState = mainPagerState.pagerState,
+            Box(modifier = if (backdrop != null) Modifier.layerBackdrop(backdrop) else Modifier) {
+                AppPager(
+                    snackbarHostState = snackbarHostState,
+                    padding = PaddingValues(
+                        start = padding.calculateStartPadding(layoutDirection) + contentStartPadding,
+                        top = padding.calculateTopPadding(),
+                        end = padding.calculateEndPadding(layoutDirection),
+                        bottom = padding.calculateBottomPadding(),
+                    ),
+                    pagerState = mainPagerState.pagerState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .imePadding()
+                        .padding(end = padding.calculateEndPadding(layoutDirection)),
+                )
+            }
+        }
+
+        if (appState.showNavigationBar) {
+            Box(
                 modifier = Modifier
-                    .imePadding()
-                    .padding(end = padding.calculateEndPadding(layoutDirection)),
-            )
+                    .align(Alignment.CenterStart)
+                    .width(railContainerWidth)
+                    .fillMaxHeight()
+                    .then(
+                        if (blurActive) {
+                            Modifier.textureBlur(
+                                backdrop = backdrop,
+                                shape = RectangleShape,
+                                blurRadius = 25f,
+                                colors = BlurDefaults.blurColors(
+                                    blendColors = listOf(
+                                        BlendColorEntry(color = MiuixTheme.colorScheme.surface.copy(0.8f)),
+                                    ),
+                                ),
+                            )
+                        } else {
+                            Modifier
+                        },
+                    )
+                    .background(barColor),
+            ) {
+                NavigationRail(
+                    modifier = Modifier.fillMaxHeight(),
+                    state = railState,
+                    color = barColor,
+                ) {
+                    navigationItems.forEachIndexed { index, item ->
+                        NavigationRailItem(
+                            selected = page == index,
+                            onClick = { mainPagerState.animateToPage(index) },
+                            icon = item.icon,
+                            label = item.label,
+                            badge = navigationItemBadge(index, appState.showNavigationBarBadge),
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/example/shared/src/commonMain/kotlin/ColorPage.kt
+++ b/example/shared/src/commonMain/kotlin/ColorPage.kt
@@ -82,6 +82,7 @@ fun ColorPage(
                     showTopAppBar = appState.showTopAppBar,
                     isWideScreen = isWideScreen,
                     scrollBehavior = topAppBarScrollBehavior,
+                    outerPadding = padding,
                     color = barColor,
                 )
             }

--- a/example/shared/src/commonMain/kotlin/IconPage.kt
+++ b/example/shared/src/commonMain/kotlin/IconPage.kt
@@ -150,6 +150,7 @@ fun IconsPage(
                         showTopAppBar = appState.showTopAppBar,
                         isWideScreen = isWideScreen,
                         scrollBehavior = topAppBarScrollBehavior,
+                        outerPadding = padding,
                         color = barColor,
                     ) {
                         Box(

--- a/example/shared/src/commonMain/kotlin/LicensePage.kt
+++ b/example/shared/src/commonMain/kotlin/LicensePage.kt
@@ -86,6 +86,7 @@ fun LicensePage(
                     showTopAppBar = appState.showTopAppBar,
                     isWideScreen = isWideScreen,
                     scrollBehavior = topAppBarScrollBehavior,
+                    outerPadding = padding,
                     color = barColor,
                     navigationIcon = {
                         BackNavigationIcon(

--- a/example/shared/src/commonMain/kotlin/MainPage.kt
+++ b/example/shared/src/commonMain/kotlin/MainPage.kt
@@ -252,6 +252,7 @@ fun MainPage(
                     showTopAppBar = appState.showTopAppBar,
                     isWideScreen = isWideScreen,
                     scrollBehavior = topAppBarScrollBehavior,
+                    outerPadding = padding,
                     color = barColor,
                     actions = {
                         TooltipBox(text = "Options") {

--- a/example/shared/src/commonMain/kotlin/MultiScaffoldTestPage.kt
+++ b/example/shared/src/commonMain/kotlin/MultiScaffoldTestPage.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBars
@@ -19,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import component.BackNavigationIcon
@@ -55,6 +58,7 @@ fun MultiScaffoldTestPage(
     val barColor = if (blurActive) Color.Transparent else MiuixTheme.colorScheme.surface
     val topAppBarScrollBehavior = MiuixScrollBehavior()
     val navigator = LocalNavigator.current
+    val layoutDirection = LocalLayoutDirection.current
 
     Scaffold(
         topBar = {
@@ -64,6 +68,7 @@ fun MultiScaffoldTestPage(
                     showTopAppBar = appState.showTopAppBar,
                     isWideScreen = isWideScreen,
                     scrollBehavior = topAppBarScrollBehavior,
+                    outerPadding = padding,
                     color = barColor,
                     navigationIcon = {
                         BackNavigationIcon(
@@ -90,8 +95,10 @@ fun MultiScaffoldTestPage(
                 .verticalScroll(scrollState)
                 .padding(
                     top = innerPadding.calculateTopPadding(),
-                    start = WindowInsets.displayCutout.asPaddingValues().calculateLeftPadding(LayoutDirection.Ltr),
-                    end = WindowInsets.displayCutout.asPaddingValues().calculateRightPadding(LayoutDirection.Ltr),
+                    start = padding.calculateStartPadding(layoutDirection) +
+                        WindowInsets.displayCutout.asPaddingValues().calculateLeftPadding(LayoutDirection.Ltr),
+                    end = padding.calculateEndPadding(layoutDirection) +
+                        WindowInsets.displayCutout.asPaddingValues().calculateRightPadding(LayoutDirection.Ltr),
                     bottom = if (isWideScreen) {
                         WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + padding.calculateBottomPadding() + 12.dp
                     } else {

--- a/example/shared/src/commonMain/kotlin/NavigateTestPage.kt
+++ b/example/shared/src/commonMain/kotlin/NavigateTestPage.kt
@@ -91,6 +91,7 @@ fun NavTestPage(
                     showTopAppBar = appState.showTopAppBar,
                     isWideScreen = isWideScreen,
                     scrollBehavior = topAppBarScrollBehavior,
+                    outerPadding = padding,
                     color = barColor,
                     navigationIcon = {
                         BackNavigationIcon(

--- a/example/shared/src/commonMain/kotlin/PullToRefreshPage.kt
+++ b/example/shared/src/commonMain/kotlin/PullToRefreshPage.kt
@@ -92,6 +92,7 @@ fun PullToRefreshPage(
                     showTopAppBar = appState.showTopAppBar,
                     isWideScreen = isWideScreen,
                     scrollBehavior = topAppBarScrollBehavior,
+                    outerPadding = padding,
                     color = barColor,
                     navigationIcon = {
                         BackNavigationIcon(

--- a/example/shared/src/commonMain/kotlin/SettingsPage.kt
+++ b/example/shared/src/commonMain/kotlin/SettingsPage.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -17,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import misc.VersionInfo
 import navigation3.Route
@@ -65,6 +68,7 @@ fun SettingsPage(
     val blurActive = backdrop != null
     val barColor = if (blurActive) Color.Transparent else MiuixTheme.colorScheme.surface
     val topAppBarScrollBehavior = MiuixScrollBehavior()
+    val layoutDirection = LocalLayoutDirection.current
 
     Scaffold(
         topBar = {
@@ -74,6 +78,7 @@ fun SettingsPage(
                     showTopAppBar = appState.showTopAppBar,
                     isWideScreen = isWideScreen,
                     scrollBehavior = topAppBarScrollBehavior,
+                    outerPadding = padding,
                     color = barColor,
                     subtitle = "v${VersionInfo.VERSION_NAME} (${VersionInfo.VERSION_CODE})",
                 )
@@ -82,7 +87,9 @@ fun SettingsPage(
     ) { innerPadding ->
         SettingsContent(
             padding = PaddingValues(
+                start = padding.calculateStartPadding(layoutDirection),
                 top = innerPadding.calculateTopPadding(),
+                end = padding.calculateEndPadding(layoutDirection),
                 bottom = padding.calculateBottomPadding(),
             ),
             topAppBarScrollBehavior = topAppBarScrollBehavior,

--- a/example/shared/src/commonMain/kotlin/TextStylePage.kt
+++ b/example/shared/src/commonMain/kotlin/TextStylePage.kt
@@ -92,6 +92,7 @@ fun TextStylePage(
                     showTopAppBar = appState.showTopAppBar,
                     isWideScreen = isWideScreen,
                     scrollBehavior = topAppBarScrollBehavior,
+                    outerPadding = padding,
                     color = barColor,
                 )
             }

--- a/example/shared/src/commonMain/kotlin/utils/PageUtils.kt
+++ b/example/shared/src/commonMain/kotlin/utils/PageUtils.kt
@@ -9,15 +9,19 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.captionBar
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import top.yukonga.miuix.kmp.basic.ScrollBehavior
@@ -44,6 +48,15 @@ fun Modifier.pageScrollModifiers(
     .fillMaxHeight()
 
 @Composable
+fun Modifier.pageHorizontalPadding(outerPadding: PaddingValues): Modifier {
+    val layoutDirection = LocalLayoutDirection.current
+    return padding(
+        start = outerPadding.calculateStartPadding(layoutDirection),
+        end = outerPadding.calculateEndPadding(layoutDirection),
+    )
+}
+
+@Composable
 fun pageContentPadding(
     innerPadding: PaddingValues,
     outerPadding: PaddingValues,
@@ -53,7 +66,10 @@ fun pageContentPadding(
     extraEnd: Dp = 0.dp,
     extraBottom: Dp = 0.dp,
 ): PaddingValues {
+    val layoutDirection = LocalLayoutDirection.current
     val topPadding = innerPadding.calculateTopPadding() + extraTop
+    val startPadding = outerPadding.calculateStartPadding(layoutDirection) + extraStart
+    val endPadding = outerPadding.calculateEndPadding(layoutDirection) + extraEnd
     val bottomPadding = outerPadding.calculateBottomPadding() + extraBottom + if (isWideScreen) {
         WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + WindowInsets.captionBar.asPaddingValues()
             .calculateBottomPadding()
@@ -61,11 +77,11 @@ fun pageContentPadding(
         0.dp
     }
 
-    return remember(topPadding, bottomPadding, extraStart, extraEnd, extraBottom) {
+    return remember(topPadding, startPadding, endPadding, bottomPadding) {
         PaddingValues(
             top = topPadding,
-            start = extraStart,
-            end = extraEnd,
+            start = startPadding,
+            end = endPadding,
             bottom = bottomPadding,
         )
     }
@@ -77,6 +93,8 @@ fun AdaptiveTopAppBar(
     showTopAppBar: Boolean,
     isWideScreen: Boolean,
     scrollBehavior: ScrollBehavior,
+    modifier: Modifier = Modifier,
+    outerPadding: PaddingValues = PaddingValues(),
     subtitle: String = "",
     color: Color = MiuixTheme.colorScheme.surface,
     navigationIcon: @Composable () -> Unit = {},
@@ -87,6 +105,7 @@ fun AdaptiveTopAppBar(
         if (isWideScreen) {
             SmallTopAppBar(
                 title = title,
+                modifier = modifier.pageHorizontalPadding(outerPadding),
                 subtitle = subtitle,
                 color = color,
                 scrollBehavior = scrollBehavior,
@@ -98,6 +117,7 @@ fun AdaptiveTopAppBar(
         } else {
             TopAppBar(
                 title = title,
+                modifier = modifier.pageHorizontalPadding(outerPadding),
                 subtitle = subtitle,
                 color = color,
                 scrollBehavior = scrollBehavior,


### PR DESCRIPTION
- Restructure layout to overlay the navigation rail with texture blur support.
- Introduce horizontal padding utilities to ensure pages respect layout bounds.
- Update all example pages to correctly handle outer padding.

Close if the implementation has any flaws.