### PR TITLE
dialog: add maxWidth support for OverlayDialog and WindowDialog

### DIFF
--- a/docs/components/overlaydialog.md
+++ b/docs/components/overlaydialog.md
@@ -75,6 +75,7 @@ Scaffold {
 | insideMargin               | DpSize                 | Dialog internal content margin                                | DialogDefaults.insideMargin      | No       |
 | defaultWindowInsetsPadding | Boolean                | Whether to apply default window insets padding                | true                                  | No       |
 | renderInRootScaffold       | Boolean                | Whether to render the dialog in the root (outermost) Scaffold. When true, the dialog covers the full screen. When false, it renders within the current Scaffold's bounds | true | No |
+| maxWidth                   | Dp                     | Maximum width of the dialog                                   | DialogDefaults.MaxWidth          | No       |
 | content                    | @Composable () -> Unit | Dialog content                                                | -                                     | Yes      |
 
 ### DialogDefaults Object
@@ -85,6 +86,7 @@ The DialogDefaults object provides default settings for the OverlayDialog compon
 
 | Property Name | Type   | Description                    |
 | ------------- | ------ | ------------------------------ |
+| MaxWidth      | Dp     | Default maximum dialog width   |
 | outsideMargin | DpSize | Default dialog external margin |
 | insideMargin  | DpSize | Default dialog internal margin |
 

--- a/docs/components/windowdialog.md
+++ b/docs/components/windowdialog.md
@@ -71,6 +71,7 @@ WindowDialog(
 | outsideMargin              | DpSize                 | Outer margin (window edges)                                   | DialogDefaults.outsideMargin     | No       |
 | insideMargin               | DpSize                 | Inner padding for dialog content                              | DialogDefaults.insideMargin      | No       |
 | defaultWindowInsetsPadding | Boolean                | Apply default insets padding (IME, nav, caption)              | true                                   | No       |
+| maxWidth                   | Dp                     | Maximum width of the dialog                                   | DialogDefaults.MaxWidth          | No       |
 | content                    | @Composable () -> Unit | Dialog content                                                | -                                      | Yes      |
 
 ### DialogDefaults
@@ -79,6 +80,7 @@ WindowDialog(
 
 | Name          | Type   | Description                      |
 | ------------- | ------ | -------------------------------- |
+| MaxWidth      | Dp     | Default maximum dialog width     |
 | outsideMargin | DpSize | Default outer margin for dialog  |
 | insideMargin  | DpSize | Default inner padding for dialog |
 

--- a/docs/zh_CN/components/overlaydialog.md
+++ b/docs/zh_CN/components/overlaydialog.md
@@ -75,6 +75,7 @@ Scaffold {
 | insideMargin               | DpSize                 | 对话框内部内容的边距                         | DialogDefaults.insideMargin      | 否       |
 | defaultWindowInsetsPadding | Boolean                | 是否应用默认窗口插入内边距                   | true                                  | 否       |
 | renderInRootScaffold       | Boolean                | 是否在根（最外层）Scaffold 中渲染对话框。为 true 时，对话框覆盖全屏。为 false 时，在当前 Scaffold 的范围内渲染 | true | 否 |
+| maxWidth                   | Dp                     | 对话框最大宽度                               | DialogDefaults.MaxWidth          | 否       |
 | content                    | @Composable () -> Unit | 对话框的内容                                 | -                                     | 是       |
 
 ### DialogDefaults
@@ -83,6 +84,7 @@ Scaffold {
 
 | 属性名        | 类型   | 说明               |
 | ------------- | ------ | ------------------ |
+| MaxWidth      | Dp     | 对话框默认最大宽度 |
 | outsideMargin | DpSize | 对话框外部默认边距 |
 | insideMargin  | DpSize | 对话框内部默认边距 |
 

--- a/docs/zh_CN/components/windowdialog.md
+++ b/docs/zh_CN/components/windowdialog.md
@@ -71,6 +71,7 @@ WindowDialog(
 | outsideMargin              | DpSize                 | 相对窗口边缘的外部边距                         | DialogDefaults.outsideMargin     | 否       |
 | insideMargin               | DpSize                 | 对话框内容内部边距                             | DialogDefaults.insideMargin      | 否       |
 | defaultWindowInsetsPadding | Boolean                | 是否应用默认窗口插入内边距（输入法/导航/标题） | true                                   | 否       |
+| maxWidth                   | Dp                     | 对话框最大宽度                                 | DialogDefaults.MaxWidth          | 否       |
 | content                    | @Composable () -> Unit | 对话框内容                                     | -                                      | 是       |
 
 ### DialogDefaults
@@ -79,6 +80,7 @@ WindowDialog(
 
 | 属性名        | 类型   | 说明               |
 | ------------- | ------ | ------------------ |
+| MaxWidth      | Dp     | 对话框默认最大宽度 |
 | outsideMargin | DpSize | 对话框外部默认边距 |
 | insideMargin  | DpSize | 对话框内部默认边距 |
 

--- a/example/shared/src/commonMain/kotlin/component/DialogSection.kt
+++ b/example/shared/src/commonMain/kotlin/component/DialogSection.kt
@@ -4,8 +4,13 @@
 package component
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListScope
@@ -14,23 +19,35 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import top.yukonga.miuix.kmp.basic.ButtonDefaults
 import top.yukonga.miuix.kmp.basic.Card
 import top.yukonga.miuix.kmp.basic.SmallTitle
+import top.yukonga.miuix.kmp.basic.Text
 import top.yukonga.miuix.kmp.basic.TextButton
+import top.yukonga.miuix.kmp.basic.VerticalDivider
+import top.yukonga.miuix.kmp.layout.DialogDefaults
 import top.yukonga.miuix.kmp.overlay.OverlayDialog
 import top.yukonga.miuix.kmp.preference.ArrowPreference
 import top.yukonga.miuix.kmp.theme.LocalDismissState
+import top.yukonga.miuix.kmp.theme.MiuixTheme
 import top.yukonga.miuix.kmp.window.WindowDialog
 
 fun LazyListScope.dialogSection() {
     item(key = "dialog") {
-        var showSuperDialog by remember { mutableStateOf(false) }
+        var showOverlayDialog by remember { mutableStateOf(false) }
         var showWindowDialog by remember { mutableStateOf(false) }
-        var superDialogHoldDown by remember { mutableStateOf(false) }
+        var overlayDialogHoldDown by remember { mutableStateOf(false) }
         var windowDialogHoldDown by remember { mutableStateOf(false) }
+        var showWideSuperDialog by remember { mutableStateOf(false) }
+        var showWideWindowDialog by remember { mutableStateOf(false) }
+        var wideSuperDialogHoldDown by remember { mutableStateOf(false) }
+        var wideWindowDialogHoldDown by remember { mutableStateOf(false) }
 
         SmallTitle(text = "Dialog")
         Card(
@@ -42,10 +59,10 @@ fun LazyListScope.dialogSection() {
                 title = "Dialog (O)",
                 summary = "Click to show an OverlayDialog",
                 onClick = {
-                    showSuperDialog = true
-                    superDialogHoldDown = true
+                    showOverlayDialog = true
+                    overlayDialogHoldDown = true
                 },
-                holdDownState = superDialogHoldDown,
+                holdDownState = overlayDialogHoldDown,
             )
             ArrowPreference(
                 title = "Dialog (W)",
@@ -56,23 +73,51 @@ fun LazyListScope.dialogSection() {
                 },
                 holdDownState = windowDialogHoldDown,
             )
+            ArrowPreference(
+                title = "Wide Dialog (O)",
+                summary = "Portrait shows a regular dialog; landscape shows a two-column dialog",
+                onClick = {
+                    showWideSuperDialog = true
+                    wideSuperDialogHoldDown = true
+                },
+                holdDownState = wideSuperDialogHoldDown,
+            )
+            ArrowPreference(
+                title = "Wide Dialog (W)",
+                summary = "Portrait shows a regular dialog; landscape shows a two-column dialog",
+                onClick = {
+                    showWideWindowDialog = true
+                    wideWindowDialogHoldDown = true
+                },
+                holdDownState = wideWindowDialogHoldDown,
+            )
         }
 
-        SuperDialogDemo(
-            show = showSuperDialog,
-            onDismissRequest = { showSuperDialog = false },
-            onDismissFinished = { superDialogHoldDown = false },
+        OverlayDialogDemo(
+            show = showOverlayDialog,
+            onDismissRequest = { showOverlayDialog = false },
+            onDismissFinished = { overlayDialogHoldDown = false },
         )
         WindowDialogDemo(
             show = showWindowDialog,
             onDismissRequest = { showWindowDialog = false },
             onDismissFinished = { windowDialogHoldDown = false },
         )
+        WideSuperDialogDemo(
+            show = showWideSuperDialog,
+            onDismissRequest = { showWideSuperDialog = false },
+            onDismissFinished = { wideSuperDialogHoldDown = false },
+        )
+        WideWindowDialogDemo(
+            show = showWideWindowDialog,
+            onDismissRequest = { showWideWindowDialog = false },
+            onDismissFinished = { wideWindowDialogHoldDown = false },
+        )
     }
 }
 
 @Composable
-private fun SuperDialogDemo(
+private fun OverlayDialogDemo(
     show: Boolean,
     onDismissRequest: () -> Unit,
     onDismissFinished: () -> Unit,
@@ -136,4 +181,142 @@ private fun WindowDialogDemo(
             }
         },
     )
+}
+
+@Composable
+private fun WideSuperDialogDemo(
+    show: Boolean,
+    onDismissRequest: () -> Unit,
+    onDismissFinished: () -> Unit,
+) {
+    val windowSize = LocalWindowInfo.current.containerDpSize
+    val isLandscape = windowSize.width > windowSize.height
+
+    OverlayDialog(
+        show = show,
+        title = if (isLandscape) null else "Wide Dialog",
+        summary = if (isLandscape) null else "Rotate to landscape to see the effect.",
+        maxWidth = if (isLandscape) 560.dp else DialogDefaults.MaxWidth,
+        onDismissRequest = onDismissRequest,
+        onDismissFinished = onDismissFinished,
+        content = {
+            WideDialogContent(isLandscape = isLandscape)
+        },
+    )
+}
+
+@Composable
+private fun WideWindowDialogDemo(
+    show: Boolean,
+    onDismissRequest: () -> Unit,
+    onDismissFinished: () -> Unit,
+) {
+    val windowSize = LocalWindowInfo.current.containerDpSize
+    val isLandscape = windowSize.width > windowSize.height
+
+    WindowDialog(
+        show = show,
+        title = if (isLandscape) null else "Wide Dialog",
+        summary = if (isLandscape) null else "Rotate to landscape to see the effect.",
+        maxWidth = if (isLandscape) 560.dp else DialogDefaults.MaxWidth,
+        onDismissRequest = onDismissRequest,
+        onDismissFinished = onDismissFinished,
+        content = {
+            WideDialogContent(isLandscape = isLandscape)
+        },
+    )
+}
+
+@Composable
+private fun WideDialogContent(
+    isLandscape: Boolean,
+) {
+    val dismissState = LocalDismissState.current
+
+    if (isLandscape) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(IntrinsicSize.Min),
+        ) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "Wide Dialog",
+                    style = MiuixTheme.textStyles.title4,
+                    color = MiuixTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.Medium,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "Rotate to landscape to see the effect.",
+                    style = MiuixTheme.textStyles.body1,
+                    color = MiuixTheme.colorScheme.onSurfaceSecondary,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            VerticalDivider(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .padding(horizontal = 20.dp),
+            )
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
+                verticalArrangement = Arrangement.spacedBy(
+                    space = 12.dp,
+                    alignment = Alignment.CenterVertically,
+                ),
+            ) {
+                TextButton(
+                    text = "Allow Once",
+                    onClick = { dismissState?.invoke() },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.textButtonColorsPrimary(),
+                )
+                TextButton(
+                    text = "Always Allow",
+                    onClick = { dismissState?.invoke() },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                TextButton(
+                    text = "Deny",
+                    onClick = { dismissState?.invoke() },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    } else {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            TextButton(
+                text = "Allow Once",
+                onClick = { dismissState?.invoke() },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.textButtonColorsPrimary(),
+            )
+            TextButton(
+                text = "Always Allow",
+                onClick = { dismissState?.invoke() },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            TextButton(
+                text = "Deny",
+                onClick = { dismissState?.invoke() },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
 }

--- a/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/layout/DialogContentLayout.kt
+++ b/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/layout/DialogContentLayout.kt
@@ -89,6 +89,7 @@ import top.yukonga.miuix.kmp.window.WindowDialog
  *   is cancelled mid-flight (e.g., by [show] toggling back to true).
  * @param defaultWindowInsetsPadding Whether to apply default window insets padding.
  * @param topInset Optional top inset override. If null, calculated from window insets.
+ * @param maxWidth The maximum width of the dialog.
  * @param content The content of the dialog.
  */
 @Suppress("ktlint:compose:modifier-not-used-at-root")
@@ -109,6 +110,7 @@ internal fun DialogContentLayout(
     onDismissFinished: (() -> Unit)? = null,
     defaultWindowInsetsPadding: Boolean = true,
     topInset: Dp? = null,
+    maxWidth: Dp = DialogDefaults.MaxWidth,
     content: @Composable () -> Unit,
 ) {
     val animationProgress = remember { Animatable(0f, visibilityThreshold = 0.0001f) }
@@ -244,6 +246,7 @@ internal fun DialogContentLayout(
             onDismissRequest = requestDismiss,
             modifier = contentModifier,
             topInset = topInset,
+            maxWidth = maxWidth,
             content = {
                 CompositionLocalProvider(LocalDismissState provides requestDismiss) {
                     content()
@@ -269,6 +272,7 @@ internal fun DialogContent(
     onDismissRequest: (() -> Unit)?,
     modifier: Modifier = Modifier,
     topInset: Dp? = null,
+    maxWidth: Dp = DialogDefaults.MaxWidth,
     content: @Composable () -> Unit,
 ) {
     val density = LocalDensity.current
@@ -307,7 +311,7 @@ internal fun DialogContent(
     }
 
     val contentModifier = modifier
-        .widthIn(max = DialogDefaults.MaxWidth)
+        .widthIn(max = maxWidth)
         .heightIn(max = if (isLargeScreen) windowHeight * (2f / 3f) else Dp.Unspecified)
         .onGloballyPositioned { coordinates ->
             dialogHeightPx.intValue = coordinates.size.height

--- a/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/overlay/OverlayDialog.kt
+++ b/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/overlay/OverlayDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import top.yukonga.miuix.kmp.layout.DialogContentLayout
 import top.yukonga.miuix.kmp.layout.DialogDefaults
@@ -34,6 +35,7 @@ import top.yukonga.miuix.kmp.utils.MiuixPopupUtils.Companion.DialogLayout
  * @param renderInRootScaffold Whether to render the dialog in the root (outermost) Scaffold.
  *   When true (default), the dialog covers the full screen. When false, it renders within the
  *   current Scaffold's bounds.
+ * @param maxWidth The maximum width of the [OverlayDialog].
  * @param content The [Composable] content of the [OverlayDialog].
  */
 @Composable
@@ -52,6 +54,7 @@ fun OverlayDialog(
     insideMargin: DpSize = DialogDefaults.insideMargin,
     defaultWindowInsetsPadding: Boolean = true,
     renderInRootScaffold: Boolean = true,
+    maxWidth: Dp = DialogDefaults.MaxWidth,
     content: @Composable () -> Unit,
 ) {
     DialogContentLayout(
@@ -82,6 +85,7 @@ fun OverlayDialog(
         onDismissRequest = onDismissRequest,
         onDismissFinished = onDismissFinished,
         defaultWindowInsetsPadding = defaultWindowInsetsPadding,
+        maxWidth = maxWidth,
         content = content,
     )
 }

--- a/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/window/WindowDialog.kt
+++ b/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/window/WindowDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.window.Dialog
 import top.yukonga.miuix.kmp.layout.DialogContentLayout
@@ -40,6 +41,7 @@ import top.yukonga.miuix.kmp.utils.platformDialogProperties
  * @param outsideMargin The margin outside the [WindowDialog].
  * @param insideMargin The margin inside the [WindowDialog].
  * @param defaultWindowInsetsPadding Whether to apply default window insets padding to the [WindowDialog].
+ * @param maxWidth The maximum width of the [WindowDialog].
  * @param content The [Composable] content of the [WindowDialog].
  */
 @Composable
@@ -57,6 +59,7 @@ fun WindowDialog(
     outsideMargin: DpSize = DialogDefaults.outsideMargin,
     insideMargin: DpSize = DialogDefaults.insideMargin,
     defaultWindowInsetsPadding: Boolean = true,
+    maxWidth: Dp = DialogDefaults.MaxWidth,
     content: @Composable () -> Unit,
 ) {
     val statusBarsPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
@@ -94,6 +97,7 @@ fun WindowDialog(
         onDismissFinished = onDismissFinished,
         defaultWindowInsetsPadding = defaultWindowInsetsPadding,
         topInset = safeTopInset,
+        maxWidth = maxWidth,
         content = {
             CompositionLocalProvider(
                 LocalDismissState provides {


### PR DESCRIPTION
- Add `maxWidth` parameter to `OverlayDialog`, `WindowDialog`, and `DialogContentLayout`.
- Define `DialogDefaults.MaxWidth` and document the new property in EN/ZH.
- Add responsive "Wide Dialog" examples showing portrait vs. landscape behavior.
- Rename old "super" variables to "overlay" in `DialogSection` for better clarity.