### PR TITLE
library: provide bridge nav back events across separate Android windows

### DIFF
--- a/miuix-nav/src/androidMain/kotlin/top/yukonga/miuix/kmp/nav/gesture/WindowNavigationEventBridge.android.kt
+++ b/miuix-nav/src/androidMain/kotlin/top/yukonga/miuix/kmp/nav/gesture/WindowNavigationEventBridge.android.kt
@@ -1,0 +1,43 @@
+// Copyright 2026, compose-miuix-ui contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package top.yukonga.miuix.kmp.nav.gesture
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalView
+import androidx.navigationevent.DirectNavigationEventInput
+import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
+import androidx.navigationevent.findViewTreeNavigationEventDispatcherOwner
+
+@Composable
+actual fun WindowNavigationEventBridge() {
+    val inheritedDispatcher =
+        LocalNavigationEventDispatcherOwner.current?.navigationEventDispatcher ?: return
+    val view = LocalView.current
+    val windowDispatcher = remember(view) {
+        view.findViewTreeNavigationEventDispatcherOwner()?.navigationEventDispatcher
+    } ?: return
+    if (windowDispatcher === inheritedDispatcher) return
+
+    val forwardingInput = remember(inheritedDispatcher) { DirectNavigationEventInput() }
+    val forwardingHandler = remember(windowDispatcher, forwardingInput) {
+        ForwardingNavigationEventHandler(forwardingInput)
+    }
+
+    DisposableEffect(inheritedDispatcher, forwardingInput) {
+        inheritedDispatcher.addInput(forwardingInput)
+        onDispose {
+            try {
+                inheritedDispatcher.removeInput(forwardingInput)
+            } catch (_: IllegalStateException) {
+                // The owning nav hierarchy already disposed this descendant dispatcher.
+            }
+        }
+    }
+    DisposableEffect(windowDispatcher, forwardingHandler) {
+        windowDispatcher.addHandler(forwardingHandler)
+        onDispose { forwardingHandler.remove() }
+    }
+}

--- a/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/gesture/WindowNavigationEventBridge.kt
+++ b/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/gesture/WindowNavigationEventBridge.kt
@@ -1,0 +1,63 @@
+// Copyright 2026, compose-miuix-ui contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package top.yukonga.miuix.kmp.nav.gesture
+
+import androidx.compose.runtime.Composable
+import androidx.navigationevent.DirectNavigationEventInput
+import androidx.navigationevent.NavigationEvent
+import androidx.navigationevent.NavigationEventHandler
+import androidx.navigationevent.NavigationEventInfo
+
+/**
+ * Forwards this platform window's back events to an explicitly inherited navigation dispatcher.
+ *
+ * This is an interoperability fallback for separate-window components that inherit a provided
+ * `LocalNavigationEventDispatcherOwner` but register their own back handler before caller content
+ * can rebind the dispatcher to the new window. On Android, call this once from the component's
+ * window content. The complete predictive-back sequence is forwarded only when the inherited
+ * dispatcher differs from the dispatcher attached to the current window.
+ *
+ * The bridge must be composed **inside** the separate window's content so it can resolve that
+ * window's dispatcher. For example, with a third-party modal bottom sheet:
+ *
+ * ```kotlin
+ * ModalBottomSheet(onDismissRequest = onDismissRequest) {
+ *     WindowNavigationEventBridge()
+ *     SheetContent()
+ * }
+ * ```
+ *
+ * Add only one bridge per window. It automatically unregisters when the window content leaves the
+ * composition. Calling it outside the separate window does not bridge that window's events.
+ *
+ * Components that control their window composition root should instead provide that window's own
+ * dispatcher there. Miuix Window* components already do this and do not need the bridge. On Skiko
+ * platforms this is a no-op because dialogs share the host window.
+ */
+@Composable
+expect fun WindowNavigationEventBridge()
+
+internal class ForwardingNavigationEventHandler(
+    private val input: DirectNavigationEventInput,
+) : NavigationEventHandler<NavigationEventInfo>(
+    initialInfo = NavigationEventInfo.None,
+    isBackEnabled = true,
+    isForwardEnabled = false,
+) {
+    override fun onBackStarted(event: NavigationEvent) {
+        input.backStarted(event)
+    }
+
+    override fun onBackProgressed(event: NavigationEvent) {
+        input.backProgressed(event)
+    }
+
+    override fun onBackCancelled() {
+        input.backCancelled()
+    }
+
+    override fun onBackCompleted() {
+        input.backCompleted()
+    }
+}

--- a/miuix-nav/src/commonTest/kotlin/top/yukonga/miuix/kmp/nav/gesture/WindowNavigationEventBridgeTest.kt
+++ b/miuix-nav/src/commonTest/kotlin/top/yukonga/miuix/kmp/nav/gesture/WindowNavigationEventBridgeTest.kt
@@ -1,0 +1,65 @@
+// Copyright 2026, compose-miuix-ui contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package top.yukonga.miuix.kmp.nav.gesture
+
+import androidx.navigationevent.DirectNavigationEventInput
+import androidx.navigationevent.NavigationEvent
+import androidx.navigationevent.NavigationEventDispatcher
+import androidx.navigationevent.NavigationEventHandler
+import androidx.navigationevent.NavigationEventInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WindowNavigationEventBridgeTest {
+    @Test
+    fun forwardsCompleteAndCancelledBackSequences() {
+        val targetDispatcher = NavigationEventDispatcher()
+        val targetInput = DirectNavigationEventInput().also(targetDispatcher::addInput)
+        val received = mutableListOf<String>()
+        val targetHandler =
+            object : NavigationEventHandler<NavigationEventInfo>(
+                initialInfo = NavigationEventInfo.None,
+                isBackEnabled = true,
+                isForwardEnabled = false,
+            ) {
+                override fun onBackStarted(event: NavigationEvent) {
+                    received += "start:${event.progress}"
+                }
+
+                override fun onBackProgressed(event: NavigationEvent) {
+                    received += "progress:${event.progress}"
+                }
+
+                override fun onBackCancelled() {
+                    received += "cancel"
+                }
+
+                override fun onBackCompleted() {
+                    received += "complete"
+                }
+            }.also(targetDispatcher::addHandler)
+
+        val sourceDispatcher = NavigationEventDispatcher()
+        val sourceInput = DirectNavigationEventInput().also(sourceDispatcher::addInput)
+        val forwardingHandler =
+            ForwardingNavigationEventHandler(targetInput).also(sourceDispatcher::addHandler)
+
+        sourceInput.backStarted(NavigationEvent(progress = 0f))
+        sourceInput.backProgressed(NavigationEvent(progress = 0.4f))
+        sourceInput.backCancelled()
+        sourceInput.backStarted(NavigationEvent(progress = 0f))
+        sourceInput.backProgressed(NavigationEvent(progress = 0.8f))
+        sourceInput.backCompleted()
+
+        assertEquals(
+            listOf("start:0.0", "progress:0.4", "cancel", "start:0.0", "progress:0.8", "complete"),
+            received,
+        )
+
+        forwardingHandler.remove()
+        targetHandler.remove()
+        sourceDispatcher.removeInput(sourceInput)
+        targetDispatcher.removeInput(targetInput)
+    }
+}

--- a/miuix-nav/src/commonTest/kotlin/top/yukonga/miuix/kmp/nav/gesture/WindowNavigationEventBridgeTest.kt
+++ b/miuix-nav/src/commonTest/kotlin/top/yukonga/miuix/kmp/nav/gesture/WindowNavigationEventBridgeTest.kt
@@ -16,7 +16,7 @@ class WindowNavigationEventBridgeTest {
     fun forwardsCompleteAndCancelledBackSequences() {
         val targetDispatcher = NavigationEventDispatcher()
         val targetInput = DirectNavigationEventInput().also(targetDispatcher::addInput)
-        val received = mutableListOf<String>()
+        val received = mutableListOf<Pair<String, Float?>>()
         val targetHandler =
             object : NavigationEventHandler<NavigationEventInfo>(
                 initialInfo = NavigationEventInfo.None,
@@ -24,19 +24,19 @@ class WindowNavigationEventBridgeTest {
                 isForwardEnabled = false,
             ) {
                 override fun onBackStarted(event: NavigationEvent) {
-                    received += "start:${event.progress}"
+                    received += "start" to event.progress
                 }
 
                 override fun onBackProgressed(event: NavigationEvent) {
-                    received += "progress:${event.progress}"
+                    received += "progress" to event.progress
                 }
 
                 override fun onBackCancelled() {
-                    received += "cancel"
+                    received += "cancel" to null
                 }
 
                 override fun onBackCompleted() {
-                    received += "complete"
+                    received += "complete" to null
                 }
             }.also(targetDispatcher::addHandler)
 
@@ -53,7 +53,14 @@ class WindowNavigationEventBridgeTest {
         sourceInput.backCompleted()
 
         assertEquals(
-            listOf("start:0.0", "progress:0.4", "cancel", "start:0.0", "progress:0.8", "complete"),
+            listOf(
+                "start" to 0f,
+                "progress" to 0.4f,
+                "cancel" to null,
+                "start" to 0f,
+                "progress" to 0.8f,
+                "complete" to null,
+            ),
             received,
         )
 

--- a/miuix-nav/src/skikoMain/kotlin/top/yukonga/miuix/kmp/nav/gesture/WindowNavigationEventBridge.skiko.kt
+++ b/miuix-nav/src/skikoMain/kotlin/top/yukonga/miuix/kmp/nav/gesture/WindowNavigationEventBridge.skiko.kt
@@ -1,0 +1,9 @@
+// Copyright 2026, compose-miuix-ui contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package top.yukonga.miuix.kmp.nav.gesture
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun WindowNavigationEventBridge() = Unit


### PR DESCRIPTION
Add `WindowNavigationEventBridge`, an opt-in compatibility layer for third-party Android window components that inherit an entry-scoped navigation dispatcher.

## Info

Material3 `ModalBottomSheet` creates its own `ComponentDialog` window while inheriting composition locals from the parent composition.

When used inside `miuix-nav`'s `NavDisplay`, the sheet inherits the entry-scoped `LocalNavigationEventDispatcherOwner`. Its internal `PredictiveBackHandler` therefore registers with the `NavEntry` dispatcher, while platform back events are sent to the dispatcher associated with the dialog window.

Because the two dispatchers are different, the sheet does not receive predictive-back progress or completion events and cannot be dismissed with the system back gesture.

Miuix window components are unaffected because they rebind `LocalNavigationEventDispatcherOwner` at their window composition root.

## Compatibility layer

`WindowNavigationEventBridge` is provided for third-party components whose window composition root cannot be modified by the caller. It should be composed once inside the separate window's content:

```kotlin
ModalBottomSheet(onDismissRequest = onDismissRequest) {
    WindowNavigationEventBridge()
    SheetContent()
}
```

On Android, the bridge compares the inherited dispatcher with the dispatcher associated with the current window. When they differ, it forwards the full predictive-back sequence, including start, progress, cancellation, and completion events.

Other platforms are unaffected because their dialogs do not use a separate Android window dispatcher.

This is an interoperability workaround, not a replacement for an upstream Material3 fix. If `ModalBottomSheet` begins rebinding the dispatcher at its dialog composition root, the bridge can be removed.
