### PR TITLE
fix: arbitrate predictive back gesture completion

### DIFF
--- a/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/core/NavDisplay.kt
+++ b/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/core/NavDisplay.kt
@@ -43,7 +43,7 @@ import androidx.navigationevent.NavigationEventDispatcherOwner
 import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import top.yukonga.miuix.kmp.nav.gesture.PredictiveBackHandler
+import top.yukonga.miuix.kmp.nav.gesture.PredictiveBackHandlerWithSessions
 import top.yukonga.miuix.kmp.nav.gesture.drivePredictiveBack
 import top.yukonga.miuix.kmp.nav.gesture.navSwipeDismissImpl
 import top.yukonga.miuix.kmp.nav.runtime.NavChange
@@ -286,6 +286,29 @@ private fun NavEntry<*>.transitionOrNull(): NavTransition? = metadata[NAV_TRANSI
 /** Reads the per-route [NavSwipeDirection] override from an entry's metadata, or null to inherit. */
 private fun NavEntry<*>.swipeDismissOrNull(): NavSwipeDirection? = metadata[NAV_SWIPE_DISMISS_METADATA_KEY] as? NavSwipeDirection
 
+/** Monotonic even/odd ownership token with generation-scoped release semantics. */
+internal class PredictiveBackOwnership {
+    var generation by mutableLongStateOf(0L)
+        private set
+
+    fun acquire(): Long {
+        generation = if (generation and 1L == 0L) generation + 1L else generation + 2L
+        return generation
+    }
+
+    fun release(lease: Long): Boolean {
+        if (generation != lease) return false
+        generation = lease + 1L
+        return true
+    }
+}
+
+private class PredictiveBackSession(
+    val ownershipLease: Long,
+    var gesture: NavGesture? = null,
+    var progressVelocity: Float = 0f,
+)
+
 /**
  * Private rendering core shared by all [NavDisplay] overloads.
  *
@@ -422,14 +445,16 @@ private fun NavDisplayLayout(
     // the shared spring settles back to topIndex. Modifier.navSwipeDismiss on the display
     // container drives the same animatedTop for the interactive edge swipe.
     // Even values are idle; every predictive-back start advances to a new odd ownership
-    // generation, and its terminal callback advances to the next even value. Pointer work can
-    // therefore detect a start+finish that occurred entirely while it was suspended.
-    var predictiveBackOwnership by remember { mutableLongStateOf(0L) }
-    val releasePredictiveBackOwnership: () -> Unit = {
-        if (predictiveBackOwnership and 1L != 0L) predictiveBackOwnership++
-    }
-    val cancelPredictiveBack: () -> Unit = {
-        releasePredictiveBackOwnership()
+    // generation, and only that session's terminal callback may advance its lease to the next
+    // even value. Pointer work can still detect a complete start+finish while suspended, without
+    // an older delayed terminal callback making a newer active session appear idle.
+    val predictiveBackOwnership = remember { PredictiveBackOwnership() }
+    val predictiveBackSessions = remember { mutableMapOf<Long, PredictiveBackSession>() }
+    val cancelPredictiveBack: (Long) -> Unit = cancel@{ sessionId ->
+        val session = predictiveBackSessions.remove(sessionId) ?: return@cancel
+        // A delayed terminal callback from an older session must not settle or release the
+        // newer predictive gesture that currently owns the shared driver.
+        if (!predictiveBackOwnership.release(session.ownershipLease)) return@cancel
         presentation.pendingSettleVelocity = 0f
         backScope.launch {
             presentation.trackSettle(phase = NavSettlePhase.Cancel, releaseVelocity = 0f) { onFrame ->
@@ -442,14 +467,12 @@ private fun NavDisplayLayout(
             presentation.gesture = null
         }
     }
-    PredictiveBackHandler(
+    PredictiveBackHandlerWithSessions(
         enabled = backStack.size > 1,
-        onProgress = { events ->
-            predictiveBackOwnership = if (predictiveBackOwnership and 1L == 0L) {
-                predictiveBackOwnership + 1L
-            } else {
-                predictiveBackOwnership + 2L
-            }
+        onProgress = { sessionId, events ->
+            val session = PredictiveBackSession(ownershipLease = predictiveBackOwnership.acquire())
+            predictiveBackSessions[sessionId] = session
+            presentation.pendingSettleVelocity = 0f
             // Per-gesture trackers: the initial touch anchors vertical-follow transitions, the
             // last two timestamped events estimate the release velocity (depth-units/sec).
             var initialTouchY = Float.NaN
@@ -462,31 +485,49 @@ private fun NavDisplayLayout(
                     if (initialTouchY.isNaN()) initialTouchY = event.touchY
                     if (event.frameTimeMillis > lastTimeMillis && lastTimeMillis != 0L) {
                         val progressVelocity = (event.progress - lastProgress) * 1000f / (event.frameTimeMillis - lastTimeMillis)
-                        presentation.pendingSettleVelocity = -progressVelocity
+                        session.progressVelocity = progressVelocity
+                        if (predictiveBackOwnership.generation == session.ownershipLease) {
+                            presentation.pendingSettleVelocity = -progressVelocity
+                        }
                     }
                     if (event.frameTimeMillis != 0L) {
                         lastProgress = event.progress
                         lastTimeMillis = event.frameTimeMillis
                     }
-                    presentation.gesture = NavGesture(
+                    val gesture = NavGesture(
                         progress = event.progress,
                         swipeEdge = event.swipeEdge,
                         touchY = event.touchY,
                         initialTouchY = initialTouchY,
                     )
+                    session.gesture = gesture
+                    if (predictiveBackOwnership.generation == session.ownershipLease) {
+                        presentation.gesture = gesture
+                    }
                 },
                 animatedTop = presentation.animatedTop,
                 topIndex = topIndex,
             )
         },
-        onCommit = {
-            val gesture = presentation.gesture
-            val progressVelocity = -presentation.pendingSettleVelocity
+        onCommit = commit@{ sessionId ->
+            if (sessionId == null) {
+                // A bare completion (Desktop ESC / programmatic back) is discrete and must commit
+                // regardless of any pointer-dismiss gesture currently stored in presentation.
+                currentOnBack.value()
+                return@commit
+            }
+            val session = predictiveBackSessions[sessionId] ?: return@commit
+            val gesture = session.gesture
+            val progressVelocity = session.progressVelocity
             val shouldCommit = gesture == null || navBackCommitDecision(
                 progress = gesture.progress,
                 velocity = progressVelocity,
             )
             if (shouldCommit) {
+                predictiveBackSessions.remove(sessionId)
+                if (predictiveBackOwnership.generation == session.ownershipLease) {
+                    presentation.pendingSettleVelocity = -progressVelocity
+                }
                 // Pop synchronously; convergence is owned by the renderer. The pop retargets
                 // animateTopTo, which picks the programmatic curve for a from-rest discrete back
                 // (identical to a programmatic pop) and the velocity-continuous spring when the
@@ -495,10 +536,10 @@ private fun NavDisplayLayout(
                 try {
                     currentOnBack.value()
                 } finally {
-                    releasePredictiveBackOwnership()
+                    predictiveBackOwnership.release(session.ownershipLease)
                 }
             } else {
-                cancelPredictiveBack()
+                cancelPredictiveBack(sessionId)
             }
         },
         onCancel = cancelPredictiveBack,
@@ -581,7 +622,7 @@ private fun NavDisplayLayout(
                 topIndex = topIndex,
                 motion = topMotion,
                 settleSink = presentation,
-                externalGestureOwnership = { predictiveBackOwnership },
+                externalGestureOwnership = { predictiveBackOwnership.generation },
                 onCommit = currentOnBack.value,
                 onCancel = {},
                 onGesture = { presentation.gesture = it },

--- a/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/core/NavDisplay.kt
+++ b/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/core/NavDisplay.kt
@@ -49,6 +49,7 @@ import top.yukonga.miuix.kmp.nav.runtime.NavChange
 import top.yukonga.miuix.kmp.nav.runtime.NavPresentation
 import top.yukonga.miuix.kmp.nav.runtime.commitVelocityFloor
 import top.yukonga.miuix.kmp.nav.runtime.isVisibleAt
+import top.yukonga.miuix.kmp.nav.runtime.navBackCommitDecision
 import top.yukonga.miuix.kmp.nav.runtime.navReconcile
 import top.yukonga.miuix.kmp.nav.runtime.relativeDepth
 import top.yukonga.miuix.kmp.nav.runtime.rememberNavPresentation
@@ -419,9 +420,25 @@ private fun NavDisplayLayout(
     // on commit onBack() pops and the renderer's animateTopTo converges to the new top; on cancel
     // the shared spring settles back to topIndex. Modifier.navSwipeDismiss on the display
     // container drives the same animatedTop for the interactive edge swipe.
+    var predictiveBackInProgress by remember { mutableStateOf(false) }
+    val cancelPredictiveBack: () -> Unit = {
+        predictiveBackInProgress = false
+        presentation.pendingSettleVelocity = 0f
+        backScope.launch {
+            presentation.trackSettle(phase = NavSettlePhase.Cancel, releaseVelocity = 0f) { onFrame ->
+                presentation.animatedTop.settleCancel(
+                    target = topIndex.toFloat(),
+                    spec = topMotion.cancel,
+                    onFrame = onFrame,
+                )
+            }
+            presentation.gesture = null
+        }
+    }
     PredictiveBackHandler(
         enabled = backStack.size > 1,
         onProgress = { events ->
+            predictiveBackInProgress = true
             // Per-gesture trackers: the initial touch anchors vertical-follow transitions, the
             // last two timestamped events estimate the release velocity (depth-units/sec).
             var initialTouchY = Float.NaN
@@ -452,22 +469,28 @@ private fun NavDisplayLayout(
             )
         },
         onCommit = {
-            // Pop synchronously; convergence is owned by the renderer. The pop retargets
-            // animateTopTo, which picks the programmatic curve for a from-rest discrete back
-            // (identical to a programmatic pop) and the velocity-continuous spring when the
-            // gesture left the float mid-flight. The gesture context stays frozen through the
-            // settle and is cleared when the leaving entry unloads.
-            currentOnBack.value()
-        },
-        onCancel = {
-            presentation.pendingSettleVelocity = 0f
-            backScope.launch {
-                presentation.trackSettle(phase = NavSettlePhase.Cancel, releaseVelocity = 0f) { onFrame ->
-                    presentation.animatedTop.settleCancel(target = topIndex.toFloat(), spec = topMotion.cancel, onFrame = onFrame)
+            val gesture = presentation.gesture
+            val progressVelocity = -presentation.pendingSettleVelocity
+            val shouldCommit = gesture == null || navBackCommitDecision(
+                progress = gesture.progress,
+                velocity = progressVelocity,
+            )
+            if (shouldCommit) {
+                // Pop synchronously; convergence is owned by the renderer. The pop retargets
+                // animateTopTo, which picks the programmatic curve for a from-rest discrete back
+                // (identical to a programmatic pop) and the velocity-continuous spring when the
+                // gesture left the float mid-flight. The gesture context stays frozen through the
+                // settle and is cleared when the leaving entry unloads.
+                try {
+                    currentOnBack.value()
+                } finally {
+                    predictiveBackInProgress = false
                 }
-                presentation.gesture = null
+            } else {
+                cancelPredictiveBack()
             }
         },
+        onCancel = cancelPredictiveBack,
     )
 
     // Unload entries that have finished leaving — either they slid fully off the front edge
@@ -547,6 +570,7 @@ private fun NavDisplayLayout(
                 topIndex = topIndex,
                 motion = topMotion,
                 settleSink = presentation,
+                blockGesture = { predictiveBackInProgress },
                 onCommit = currentOnBack.value,
                 onCancel = {},
                 onGesture = { presentation.gesture = it },

--- a/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/core/NavDisplay.kt
+++ b/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/core/NavDisplay.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -420,9 +421,15 @@ private fun NavDisplayLayout(
     // on commit onBack() pops and the renderer's animateTopTo converges to the new top; on cancel
     // the shared spring settles back to topIndex. Modifier.navSwipeDismiss on the display
     // container drives the same animatedTop for the interactive edge swipe.
-    var predictiveBackInProgress by remember { mutableStateOf(false) }
+    // Even values are idle; every predictive-back start advances to a new odd ownership
+    // generation, and its terminal callback advances to the next even value. Pointer work can
+    // therefore detect a start+finish that occurred entirely while it was suspended.
+    var predictiveBackOwnership by remember { mutableLongStateOf(0L) }
+    val releasePredictiveBackOwnership: () -> Unit = {
+        if (predictiveBackOwnership and 1L != 0L) predictiveBackOwnership++
+    }
     val cancelPredictiveBack: () -> Unit = {
-        predictiveBackInProgress = false
+        releasePredictiveBackOwnership()
         presentation.pendingSettleVelocity = 0f
         backScope.launch {
             presentation.trackSettle(phase = NavSettlePhase.Cancel, releaseVelocity = 0f) { onFrame ->
@@ -438,7 +445,11 @@ private fun NavDisplayLayout(
     PredictiveBackHandler(
         enabled = backStack.size > 1,
         onProgress = { events ->
-            predictiveBackInProgress = true
+            predictiveBackOwnership = if (predictiveBackOwnership and 1L == 0L) {
+                predictiveBackOwnership + 1L
+            } else {
+                predictiveBackOwnership + 2L
+            }
             // Per-gesture trackers: the initial touch anchors vertical-follow transitions, the
             // last two timestamped events estimate the release velocity (depth-units/sec).
             var initialTouchY = Float.NaN
@@ -484,7 +495,7 @@ private fun NavDisplayLayout(
                 try {
                     currentOnBack.value()
                 } finally {
-                    predictiveBackInProgress = false
+                    releasePredictiveBackOwnership()
                 }
             } else {
                 cancelPredictiveBack()
@@ -570,7 +581,7 @@ private fun NavDisplayLayout(
                 topIndex = topIndex,
                 motion = topMotion,
                 settleSink = presentation,
-                blockGesture = { predictiveBackInProgress },
+                externalGestureOwnership = { predictiveBackOwnership },
                 onCommit = currentOnBack.value,
                 onCancel = {},
                 onGesture = { presentation.gesture = it },

--- a/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/gesture/NavSwipeDismiss.kt
+++ b/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/gesture/NavSwipeDismiss.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.util.VelocityTracker
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import top.yukonga.miuix.kmp.nav.runtime.NavSettleSink
 import top.yukonga.miuix.kmp.nav.runtime.anchoredProgress
@@ -29,6 +31,7 @@ import top.yukonga.miuix.kmp.nav.transition.NavMotion
 import top.yukonga.miuix.kmp.nav.transition.NavSettlePhase
 import top.yukonga.miuix.kmp.nav.transition.NavSwipeDirection
 import top.yukonga.miuix.kmp.nav.transition.NavSwipeEdge
+import kotlin.coroutines.coroutineContext
 import kotlin.math.abs
 
 /**
@@ -120,8 +123,10 @@ fun Modifier.navSwipeDismiss(
  * Implementation body shared by the public [navSwipeDismiss] and NavDisplay's internal wiring:
  * [settleSink], when present, publishes the release settle as a
  * [top.yukonga.miuix.kmp.nav.transition.NavSettle] context (the bare public modifier drives and
- * settles but publishes no context). [blockGesture] reports whether another source, such as system
- * predictive back, owns the pointer sequence; ownership is latched until that sequence ends.
+ * settles but publishes no context). [externalGestureOwnership] is an even/odd generation token:
+ * odd means another source (such as system predictive back) currently owns the gesture, and every
+ * ownership change advances the value. A pointer sequence latches any generation change so queued
+ * work cannot resume after a fast external start+finish cycle.
  */
 @Suppress("ktlint:compose:modifier-composed-check")
 internal fun Modifier.navSwipeDismissImpl(
@@ -131,7 +136,7 @@ internal fun Modifier.navSwipeDismissImpl(
     topIndex: Int,
     motion: NavMotion,
     settleSink: NavSettleSink?,
-    blockGesture: () -> Boolean = { false },
+    externalGestureOwnership: () -> Long = { 0L },
     onCommit: () -> Unit,
     onCancel: () -> Unit,
     onGesture: (NavGesture?) -> Unit,
@@ -140,7 +145,7 @@ internal fun Modifier.navSwipeDismissImpl(
 
     val scope = rememberCoroutineScope()
     val currentMotion = rememberUpdatedState(motion)
-    val currentBlockGesture = rememberUpdatedState(blockGesture)
+    val currentExternalGestureOwnership = rememberUpdatedState(externalGestureOwnership)
     val currentOnCommit = rememberUpdatedState(onCommit)
     val currentOnCancel = rememberUpdatedState(onCancel)
     val currentOnGesture = rememberUpdatedState(onGesture)
@@ -163,6 +168,7 @@ internal fun Modifier.navSwipeDismissImpl(
     }
 
     this.pointerInput(enabled, direction, topIndex) {
+        val pointerInputContext = coroutineContext
         awaitEachGesture {
             // Layout extent along the gesture axis, used to normalise finger travel into 0f..1f progress.
             // Read per-gesture from the live pointer scope so a resize between gestures is picked up.
@@ -170,7 +176,21 @@ internal fun Modifier.navSwipeDismissImpl(
             val slop = viewConfiguration.touchSlop
 
             val down = awaitFirstDown(requireUnconsumed = false)
-            var blockedByExternalGesture = currentBlockGesture.value()
+            val initialExternalOwnership = currentExternalGestureOwnership.value()
+            var sequenceJob: Job? = null
+            var blockedByExternalGesture = false
+            fun externalGestureOwnsSequence(): Boolean {
+                if (!blockedByExternalGesture && (
+                        initialExternalOwnership and 1L != 0L ||
+                            currentExternalGestureOwnership.value() != initialExternalOwnership
+                        )
+                ) {
+                    blockedByExternalGesture = true
+                    sequenceJob?.cancel()
+                }
+                return blockedByExternalGesture
+            }
+
             // Tracks pointer position over time for an accurate instantaneous release velocity. Sampled
             // from the down so the velocity window is populated even before the gesture engages.
             val velocityTracker = VelocityTracker()
@@ -183,8 +203,7 @@ internal fun Modifier.navSwipeDismissImpl(
             while (!claimed) {
                 val event = awaitPointerEvent(PointerEventPass.Initial)
                 val change = event.changes.firstOrNull { it.id == down.id } ?: return@awaitEachGesture
-                blockedByExternalGesture = blockedByExternalGesture || currentBlockGesture.value()
-                if (blockedByExternalGesture) return@awaitEachGesture
+                if (externalGestureOwnsSequence()) return@awaitEachGesture
                 velocityTracker.addPosition(change.uptimeMillis, change.position)
                 if (!change.pressed) return@awaitEachGesture // lifted before engaging: a tap / short press
                 val delta = change.positionChange()
@@ -201,6 +220,13 @@ internal fun Modifier.navSwipeDismissImpl(
                 }
             }
 
+            // Anchor and finger-snap work belongs to this pointer sequence, not to the whole
+            // composition. Parenting it to pointerInput also cancels queued mutations when
+            // this modifier restarts; external ownership cancels it explicitly below.
+            val activeSequenceJob = Job(pointerInputContext[Job])
+            sequenceJob = activeSequenceJob
+            val sequenceScope = CoroutineScope(pointerInputContext + activeSequenceJob)
+
             // --- Grab anchor (invariant 6): sampled atomically with halting the in-flight settle,
             // inside the FIRST driver coroutine rather than this pointer handler (this scope is
             // @RestrictsSuspension — a foreign suspend call like stop() cannot run here). Between
@@ -215,8 +241,10 @@ internal fun Modifier.navSwipeDismissImpl(
             // Such pre-anchor snaps are dropped at the launch site below (and snapToFinger itself
             // rejects a NaN anchor): a NaN written into the driving float would be unrecoverable. ---
             var anchor = Float.NaN
-            scope.launch {
+            sequenceScope.launch {
+                if (externalGestureOwnsSequence()) return@launch
                 animatedTop.stop()
+                if (externalGestureOwnsSequence()) return@launch
                 anchor = topIndex - animatedTop.value
             }
 
@@ -227,8 +255,7 @@ internal fun Modifier.navSwipeDismissImpl(
             while (true) {
                 val event = awaitPointerEvent(PointerEventPass.Initial)
                 val change = event.changes.firstOrNull { it.id == down.id } ?: break
-                blockedByExternalGesture = blockedByExternalGesture || currentBlockGesture.value()
-                if (blockedByExternalGesture) return@awaitEachGesture
+                if (externalGestureOwnsSequence()) return@awaitEachGesture
                 velocityTracker.addPosition(change.uptimeMillis, change.position)
                 if (!change.pressed) {
                     change.consume()
@@ -240,12 +267,13 @@ internal fun Modifier.navSwipeDismissImpl(
                 // Unclamped here; anchoredProgress clamps the total to [min(anchor, 0), MAX_FINGER_PROGRESS].
                 val fingerProgress = dismissSign * drag / extent
                 val touchY = change.position.y
-                scope.launch {
+                sequenceScope.launch {
                     // Pre-anchor event (stop() above still unwinding a mid-flight settle): drop it.
                     // At most the first 1-2 events on desktop/web; the first executed snap still
                     // lands exactly on the sampled anchor, so the zero-jump grab is preserved.
-                    if (anchor.isNaN()) return@launch
+                    if (externalGestureOwnsSequence() || anchor.isNaN()) return@launch
                     animatedTop.snapToFinger(topIndex = topIndex, progress = fingerProgress, anchor = anchor)
+                    if (externalGestureOwnsSequence()) return@launch
                     // Published inside the driver coroutine so the anchor is always the sampled one.
                     currentOnGesture.value(
                         NavGesture(
@@ -258,8 +286,7 @@ internal fun Modifier.navSwipeDismissImpl(
                 }
             }
 
-            blockedByExternalGesture = blockedByExternalGesture || currentBlockGesture.value()
-            if (blockedByExternalGesture) return@awaitEachGesture
+            if (externalGestureOwnsSequence()) return@awaitEachGesture
 
             // --- Release: velocity-first / position-fallback, velocity-continuous spring handoff. ---
             // If the finger lifted before the anchor coroutine ran (claim -> immediate lift), fall
@@ -296,6 +323,7 @@ internal fun Modifier.navSwipeDismissImpl(
                 } else {
                     currentOnCommit.value()
                     scope.launch {
+                        if (externalGestureOwnsSequence()) return@launch
                         // Seed the governing commit curve with the release velocity. The
                         // no-overshoot floor applies only while the commit spec keeps overshoot
                         // clamped (the default): even a critically damped spring crosses its
@@ -327,6 +355,7 @@ internal fun Modifier.navSwipeDismissImpl(
                 // kept, preserving the snap -> spring velocity continuity; it points away from the cancel
                 // target, so it can never cross it (no bounce, no overshoot floor needed on this branch).
                 scope.launch {
+                    if (externalGestureOwnsSequence()) return@launch
                     val settleBody: suspend (onFrame: (() -> Unit)?) -> Unit = { onFrame ->
                         animatedTop.settleCancel(
                             target = topIndex.toFloat(),
@@ -342,12 +371,17 @@ internal fun Modifier.navSwipeDismissImpl(
                     } else {
                         settleBody(null)
                     }
+                    if (externalGestureOwnsSequence()) return@launch
                     // The gesture context stays frozen through the settle (no pivot snap at lift)
                     // and is released only now, with the entry back at rest.
                     currentOnGesture.value(null)
                     currentOnCancel.value()
                 }
             }
+
+            // Normal release keeps FIFO behavior: already queued final snaps may finish
+            // before the composition-scope settle, but no new sequence work can be added.
+            activeSequenceJob.complete()
         }
     }
 }

--- a/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/gesture/NavSwipeDismiss.kt
+++ b/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/gesture/NavSwipeDismiss.kt
@@ -120,7 +120,8 @@ fun Modifier.navSwipeDismiss(
  * Implementation body shared by the public [navSwipeDismiss] and NavDisplay's internal wiring:
  * [settleSink], when present, publishes the release settle as a
  * [top.yukonga.miuix.kmp.nav.transition.NavSettle] context (the bare public modifier drives and
- * settles but publishes no context).
+ * settles but publishes no context). [blockGesture] reports whether another source, such as system
+ * predictive back, owns the pointer sequence; ownership is latched until that sequence ends.
  */
 @Suppress("ktlint:compose:modifier-composed-check")
 internal fun Modifier.navSwipeDismissImpl(
@@ -130,6 +131,7 @@ internal fun Modifier.navSwipeDismissImpl(
     topIndex: Int,
     motion: NavMotion,
     settleSink: NavSettleSink?,
+    blockGesture: () -> Boolean = { false },
     onCommit: () -> Unit,
     onCancel: () -> Unit,
     onGesture: (NavGesture?) -> Unit,
@@ -138,6 +140,7 @@ internal fun Modifier.navSwipeDismissImpl(
 
     val scope = rememberCoroutineScope()
     val currentMotion = rememberUpdatedState(motion)
+    val currentBlockGesture = rememberUpdatedState(blockGesture)
     val currentOnCommit = rememberUpdatedState(onCommit)
     val currentOnCancel = rememberUpdatedState(onCancel)
     val currentOnGesture = rememberUpdatedState(onGesture)
@@ -167,6 +170,7 @@ internal fun Modifier.navSwipeDismissImpl(
             val slop = viewConfiguration.touchSlop
 
             val down = awaitFirstDown(requireUnconsumed = false)
+            var blockedByExternalGesture = currentBlockGesture.value()
             // Tracks pointer position over time for an accurate instantaneous release velocity. Sampled
             // from the down so the velocity window is populated even before the gesture engages.
             val velocityTracker = VelocityTracker()
@@ -179,6 +183,8 @@ internal fun Modifier.navSwipeDismissImpl(
             while (!claimed) {
                 val event = awaitPointerEvent(PointerEventPass.Initial)
                 val change = event.changes.firstOrNull { it.id == down.id } ?: return@awaitEachGesture
+                blockedByExternalGesture = blockedByExternalGesture || currentBlockGesture.value()
+                if (blockedByExternalGesture) return@awaitEachGesture
                 velocityTracker.addPosition(change.uptimeMillis, change.position)
                 if (!change.pressed) return@awaitEachGesture // lifted before engaging: a tap / short press
                 val delta = change.positionChange()
@@ -221,6 +227,8 @@ internal fun Modifier.navSwipeDismissImpl(
             while (true) {
                 val event = awaitPointerEvent(PointerEventPass.Initial)
                 val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                blockedByExternalGesture = blockedByExternalGesture || currentBlockGesture.value()
+                if (blockedByExternalGesture) return@awaitEachGesture
                 velocityTracker.addPosition(change.uptimeMillis, change.position)
                 if (!change.pressed) {
                     change.consume()
@@ -249,6 +257,9 @@ internal fun Modifier.navSwipeDismissImpl(
                     )
                 }
             }
+
+            blockedByExternalGesture = blockedByExternalGesture || currentBlockGesture.value()
+            if (blockedByExternalGesture) return@awaitEachGesture
 
             // --- Release: velocity-first / position-fallback, velocity-continuous spring handoff. ---
             // If the finger lifted before the anchor coroutine ran (claim -> immediate lift), fall

--- a/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/gesture/PredictiveBackHandler.kt
+++ b/miuix-nav/src/commonMain/kotlin/top/yukonga/miuix/kmp/nav/gesture/PredictiveBackHandler.kt
@@ -84,6 +84,20 @@ fun PredictiveBackHandler(
     onProgress: suspend (Flow<NavBackEvent>) -> Unit,
     onCommit: () -> Unit,
     onCancel: () -> Unit,
+) = PredictiveBackHandlerWithSessions(
+    enabled = enabled,
+    onProgress = { _, events -> onProgress(events) },
+    onCommit = { onCommit() },
+    onCancel = { onCancel() },
+)
+
+/** Session-aware wiring used internally when terminal work must be tied to its originating gesture. */
+@Composable
+internal fun PredictiveBackHandlerWithSessions(
+    enabled: Boolean,
+    onProgress: suspend (sessionId: Long, events: Flow<NavBackEvent>) -> Unit,
+    onCommit: (sessionId: Long?) -> Unit,
+    onCancel: (sessionId: Long) -> Unit,
 ) {
     // No dispatcher owner means the host has no back-event source at all (never the case on
     // Android or under the multiplatform window hosts); the handler is simply inert then.
@@ -116,8 +130,9 @@ fun PredictiveBackHandler(
  * Per gesture: [onBackStarted] opens an unbounded channel and launches the collector
  * ([currentOnProgress]); [onBackProgressed] enqueues; [onBackCompleted] closes the stream, waits
  * for the collector to drain the tail, then fires [currentOnCommit]; [onBackCancelled] cancels
- * the collector and fires [currentOnCancel]. A terminal callback with no open session (a
- * discrete trigger such as a Desktop ESC press) commits directly.
+ * the collector and fires [currentOnCancel]. Progress and terminal callbacks carry the originating
+ * session ID so delayed work cannot resolve a newer gesture. A completed callback with no open
+ * session (a discrete trigger such as a Desktop ESC press) reports a null ID and commits directly.
  */
 internal class NavigationEventFlowAdapter(
     private val scope: CoroutineScope,
@@ -126,12 +141,14 @@ internal class NavigationEventFlowAdapter(
     isBackEnabled = false,
     isForwardEnabled = false,
 ) {
-    var currentOnProgress: suspend (Flow<NavBackEvent>) -> Unit = {}
-    var currentOnCommit: () -> Unit = {}
-    var currentOnCancel: () -> Unit = {}
+    var currentOnProgress: suspend (sessionId: Long, events: Flow<NavBackEvent>) -> Unit = { _, _ -> }
+    var currentOnCommit: (sessionId: Long?) -> Unit = {}
+    var currentOnCancel: (sessionId: Long) -> Unit = {}
 
     private var channel: Channel<NavBackEvent>? = null
     private var collector: Job? = null
+    private var activeSessionId: Long? = null
+    private var nextSessionId = 0L
 
     // The base-class callbacks are protected; the bodies live in internal handle* twins so the
     // ordering semantics stay unit-testable without a dispatcher.
@@ -144,10 +161,12 @@ internal class NavigationEventFlowAdapter(
     override fun onBackCancelled() = handleBackCancelled()
 
     internal fun handleBackStarted(event: NavigationEvent) {
+        val sessionId = ++nextSessionId
         val ch = Channel<NavBackEvent>(capacity = Channel.UNLIMITED)
         channel = ch
+        activeSessionId = sessionId
         val onProgress = currentOnProgress
-        collector = scope.launch { onProgress(ch.receiveAsFlow()) }
+        collector = scope.launch { onProgress(sessionId, ch.receiveAsFlow()) }
         ch.trySend(event.toNavBackEvent())
     }
 
@@ -158,13 +177,15 @@ internal class NavigationEventFlowAdapter(
     internal fun handleBackCompleted() {
         val ch = channel
         val job = collector
+        val sessionId = activeSessionId
         channel = null
         collector = null
-        if (ch == null || job == null) {
+        activeSessionId = null
+        if (ch == null || job == null || sessionId == null) {
             // Discrete trigger: no gesture session was ever started. Commit directly; the
             // commit settle animates the pop through the shared spring from wherever an
             // in-flight transition currently sits.
-            currentOnCommit()
+            currentOnCommit(null)
             return
         }
         ch.close()
@@ -173,21 +194,23 @@ internal class NavigationEventFlowAdapter(
             // Let the collector drain trailing progress events and return before committing,
             // so no stale snap can land after the commit settle has taken over the driver.
             job.join()
-            onCommit()
+            onCommit(sessionId)
         }
     }
 
     internal fun handleBackCancelled() {
         val ch = channel
         val job = collector
+        val sessionId = activeSessionId
         channel = null
         collector = null
-        if (ch == null || job == null) return
+        activeSessionId = null
+        if (ch == null || job == null || sessionId == null) return
         ch.close()
         val onCancel = currentOnCancel
         scope.launch {
             job.cancelAndJoin()
-            onCancel()
+            onCancel(sessionId)
         }
     }
 }

--- a/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/core/NavNestedStressTest.kt
+++ b/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/core/NavNestedStressTest.kt
@@ -251,6 +251,85 @@ class NavNestedStressTest {
         assertEquals(2, inner.size, "committed back session mid-settle must pop")
         probe("back session committed mid-settle")
     }
+
+    @Test
+    fun completedPredictiveBackReturningTowardRest_isReclassifiedAsCancel() = runComposeUiTest {
+        mainClock.autoAdvance = false
+        val owner = TestOwner()
+        val stack = navBackStackOf(FzRoot, FzTop)
+        setContent {
+            CompositionLocalProvider(LocalNavigationEventDispatcherOwner provides owner) {
+                NavDisplay(stack, effects = NavDisplayEffects(blockInputDuringTransition = false)) {
+                    entry<FzRoot> { Box(Modifier.fillMaxSize().background(Color.Gray)) }
+                    entry<FzTop> { Box(Modifier.fillMaxSize().background(Color.Black)) }
+                }
+            }
+        }
+        mainClock.advanceTimeBy(100)
+        waitForIdle()
+
+        runOnIdle {
+            owner.input.backStarted(NavigationEvent(progress = 0f, frameTimeMillis = 1_000L))
+            owner.input.backProgressed(NavigationEvent(progress = 0.7f, frameTimeMillis = 1_100L))
+            owner.input.backProgressed(NavigationEvent(progress = 0.45f, frameTimeMillis = 1_150L))
+            owner.input.backProgressed(NavigationEvent(progress = 0.2f, frameTimeMillis = 1_200L))
+            // Mirrors Samsung: the terminal callback says complete even though the final velocity
+            // is strongly back toward rest. The shared velocity-first rule must win.
+            owner.input.backCompleted()
+        }
+        repeat(3) {
+            mainClock.advanceTimeBy(600)
+            waitForIdle()
+        }
+
+        assertEquals(
+            listOf<NavKey>(FzRoot, FzTop),
+            stack.toList(),
+            "a completed callback received during strong return motion must restore the top entry",
+        )
+    }
+
+    @Test
+    fun rapidCancelledPredictiveBack_doesNotPopOrSkipUnderlyingEntry() = runComposeUiTest {
+        mainClock.autoAdvance = false
+        val owner = TestOwner()
+        val stack = navBackStackOf(FzRoot, FzNested, FzTop)
+        setContent {
+            CompositionLocalProvider(LocalNavigationEventDispatcherOwner provides owner) {
+                NavDisplay(stack, effects = NavDisplayEffects(blockInputDuringTransition = false)) {
+                    entry<FzRoot> { Box(Modifier.fillMaxSize().background(Color.Gray)) }
+                    entry<FzNested> { Box(Modifier.fillMaxSize().background(Color.White)) }
+                    entry<FzTop> { Box(Modifier.fillMaxSize().background(Color.Black)) }
+                }
+            }
+        }
+        mainClock.advanceTimeBy(100)
+        waitForIdle()
+
+        repeat(50) { index ->
+            runOnIdle {
+                owner.input.backStarted(NavigationEvent(progress = 0f))
+                owner.input.backProgressed(
+                    NavigationEvent(progress = (index % 8 + 1) / 10f),
+                )
+                owner.input.backCancelled()
+            }
+            // Start the next gesture while the previous cancellation spring is still restoring.
+            mainClock.advanceTimeBy(16)
+            waitForIdle()
+            assertEquals(
+                listOf<NavKey>(FzRoot, FzNested, FzTop),
+                stack.toList(),
+                "cancelled gesture $index must not mutate the back stack",
+            )
+        }
+
+        repeat(4) {
+            mainClock.advanceTimeBy(600)
+            waitForIdle()
+        }
+        assertEquals(listOf<NavKey>(FzRoot, FzNested, FzTop), stack.toList())
+    }
 }
 
 @Composable

--- a/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/core/NavNestedStressTest.kt
+++ b/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/core/NavNestedStressTest.kt
@@ -18,7 +18,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import androidx.navigationevent.DirectNavigationEventInput
@@ -26,6 +28,7 @@ import androidx.navigationevent.NavigationEvent
 import androidx.navigationevent.NavigationEventDispatcher
 import androidx.navigationevent.NavigationEventDispatcherOwner
 import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
+import top.yukonga.miuix.kmp.nav.transition.NavSwipeDirection
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -287,6 +290,39 @@ class NavNestedStressTest {
             stack.toList(),
             "a completed callback received during strong return motion must restore the top entry",
         )
+    }
+
+    @Test
+    fun discreteBackDuringPointerPreview_commitsUnconditionally() = runComposeUiTest {
+        val owner = TestOwner()
+        val stack = navBackStackOf(FzRoot, FzTop)
+        setContent {
+            CompositionLocalProvider(LocalNavigationEventDispatcherOwner provides owner) {
+                NavDisplay(stack, effects = NavDisplayEffects(blockInputDuringTransition = false)) {
+                    entry<FzRoot> { Box(Modifier.fillMaxSize().background(Color.Gray)) }
+                    entry<FzTop>(swipeDismiss = NavSwipeDirection.LeftToRight) {
+                        Box(Modifier.fillMaxSize().background(Color.Black))
+                    }
+                }
+            }
+        }
+        waitForIdle()
+
+        // Hold a low-progress pointer preview whose shared gesture would classify as cancel.
+        onRoot().performTouchInput {
+            down(Offset(width * 0.05f, centerY))
+            moveTo(Offset(width * 0.2f, centerY))
+            repeat(4) { moveTo(Offset(width * 0.2f, centerY), delayMillis = 100) }
+        }
+        waitForIdle()
+
+        // A bare completed callback is Desktop ESC/programmatic back, not completion of the
+        // pointer preview, and must therefore pop without consulting that preview's progress.
+        runOnIdle { owner.input.backCompleted() }
+        onRoot().performTouchInput { up() }
+        waitForIdle()
+
+        assertEquals(listOf<NavKey>(FzRoot), stack.toList())
     }
 
     @Test

--- a/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/core/PredictiveBackOwnershipTest.kt
+++ b/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/core/PredictiveBackOwnershipTest.kt
@@ -1,0 +1,24 @@
+// Copyright 2026, compose-miuix-ui contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package top.yukonga.miuix.kmp.nav.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PredictiveBackOwnershipTest {
+    @Test
+    fun staleLeaseCannotReleaseNewerSession() {
+        val ownership = PredictiveBackOwnership()
+        val sessionA = ownership.acquire()
+        val sessionB = ownership.acquire()
+
+        assertEquals(3L, ownership.generation)
+        assertFalse(ownership.release(sessionA))
+        assertEquals(3L, ownership.generation)
+        assertTrue(ownership.release(sessionB))
+        assertEquals(4L, ownership.generation)
+    }
+}

--- a/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/gesture/NavSwipeScrollConflictTest.kt
+++ b/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/gesture/NavSwipeScrollConflictTest.kt
@@ -16,7 +16,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.ExperimentalTestApi
@@ -69,7 +72,7 @@ class NavSwipeScrollConflictTest {
                         topIndex = 1,
                         motion = NavMotion.Default,
                         settleSink = null,
-                        blockGesture = { true },
+                        externalGestureOwnership = { 1L },
                         onCommit = { commits++ },
                         onCancel = {},
                         onGesture = {},
@@ -82,6 +85,58 @@ class NavSwipeScrollConflictTest {
         waitForIdle()
 
         assertEquals(0, commits, "system predictive back ownership must suppress the pointer recognizer")
+    }
+
+    @Test
+    fun completedPredictiveBackOwnershipCycleCancelsClaimedPointerWork() = runComposeUiTest {
+        var ownership by mutableLongStateOf(0L)
+        var commits = 0
+        var pointerGestureUpdates = 0
+        setContent {
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .navSwipeDismissImpl(
+                        enabled = true,
+                        direction = NavSwipeDirection.LeftToRight,
+                        animatedTop = remember { Animatable(1f) },
+                        topIndex = 1,
+                        motion = NavMotion.Default,
+                        settleSink = null,
+                        externalGestureOwnership = { ownership },
+                        onCommit = { commits++ },
+                        onCancel = {},
+                        onGesture = { if (it != null) pointerGestureUpdates++ },
+                    ),
+            )
+        }
+        waitForIdle()
+
+        // Claim the pointer recognizer and allow its first update to run.
+        onRoot().performTouchInput {
+            down(Offset(width * 0.05f, centerY))
+            moveTo(Offset(width * 0.25f, centerY))
+            moveTo(Offset(width * 0.35f, centerY))
+        }
+        waitForIdle()
+        val updatesBeforeOwnershipChange = pointerGestureUpdates
+        assertTrue(updatesBeforeOwnershipChange > 0, "the pointer sequence must be claimed before takeover")
+
+        // An even generation means predictive back has already started and finished. The pointer
+        // sequence must still observe that ownership changed while it was suspended.
+        runOnIdle { ownership = 2L }
+        onRoot().performTouchInput {
+            moveTo(Offset(width * 0.8f, centerY))
+            up()
+        }
+        waitForIdle()
+
+        assertEquals(0, commits, "a stale claimed pointer sequence must not commit")
+        assertEquals(
+            updatesBeforeOwnershipChange,
+            pointerGestureUpdates,
+            "queued pointer work must not publish after predictive-back ownership changes",
+        )
     }
 
     @Test

--- a/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/gesture/NavSwipeScrollConflictTest.kt
+++ b/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/gesture/NavSwipeScrollConflictTest.kt
@@ -3,6 +3,7 @@
 
 package top.yukonga.miuix.kmp.nav.gesture
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.ExperimentalTestApi
@@ -28,6 +30,7 @@ import top.yukonga.miuix.kmp.nav.core.NavDisplay
 import top.yukonga.miuix.kmp.nav.core.NavDisplayEffects
 import top.yukonga.miuix.kmp.nav.core.NavKey
 import top.yukonga.miuix.kmp.nav.core.navBackStackOf
+import top.yukonga.miuix.kmp.nav.transition.NavMotion
 import top.yukonga.miuix.kmp.nav.transition.NavSwipeDirection
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -51,6 +54,35 @@ private data object HorizontalPage : NavKey
  */
 @OptIn(ExperimentalTestApi::class)
 class NavSwipeScrollConflictTest {
+
+    @Test
+    fun predictiveBackOwnershipBlocksPointerDismissCommit() = runComposeUiTest {
+        var commits = 0
+        setContent {
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .navSwipeDismissImpl(
+                        enabled = true,
+                        direction = NavSwipeDirection.LeftToRight,
+                        animatedTop = remember { Animatable(1f) },
+                        topIndex = 1,
+                        motion = NavMotion.Default,
+                        settleSink = null,
+                        blockGesture = { true },
+                        onCommit = { commits++ },
+                        onCancel = {},
+                        onGesture = {},
+                    ),
+            )
+        }
+        waitForIdle()
+
+        onRoot().performTouchInput { swipeRight(startX = width * 0.05f, endX = width * 0.95f) }
+        waitForIdle()
+
+        assertEquals(0, commits, "system predictive back ownership must suppress the pointer recognizer")
+    }
 
     @Test
     fun crossAxisDragScrollsThePageWithoutEngagingDismiss() = runComposeUiTest {

--- a/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/gesture/NavigationEventFlowAdapterTest.kt
+++ b/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/gesture/NavigationEventFlowAdapterTest.kt
@@ -23,8 +23,8 @@ class NavigationEventFlowAdapterTest {
     fun gesture_streamsEventsThenCommitsAfterDrain() = runBlocking {
         val order = mutableListOf<String>()
         val adapter = NavigationEventFlowAdapter(this)
-        adapter.currentOnProgress = { events -> events.collect { order += "progress:${it.progress}" } }
-        adapter.currentOnCommit = { order += "commit" }
+        adapter.currentOnProgress = { _, events -> events.collect { order += "progress:${it.progress}" } }
+        adapter.currentOnCommit = { _ -> order += "commit" }
 
         adapter.handleBackStarted(NavigationEvent(progress = 0f))
         adapter.handleBackProgressed(NavigationEvent(progress = 0.5f))
@@ -40,9 +40,9 @@ class NavigationEventFlowAdapterTest {
         var committed = false
         var cancelled = false
         val adapter = NavigationEventFlowAdapter(this)
-        adapter.currentOnProgress = { events -> events.collect { } }
-        adapter.currentOnCommit = { committed = true }
-        adapter.currentOnCancel = { cancelled = true }
+        adapter.currentOnProgress = { _, events -> events.collect { } }
+        adapter.currentOnCommit = { _ -> committed = true }
+        adapter.currentOnCancel = { _ -> cancelled = true }
 
         adapter.handleBackStarted(NavigationEvent(progress = 0f))
         adapter.handleBackProgressed(NavigationEvent(progress = 0.25f))
@@ -58,8 +58,8 @@ class NavigationEventFlowAdapterTest {
         var progressSessions = 0
         var committed = false
         val adapter = NavigationEventFlowAdapter(this)
-        adapter.currentOnProgress = { progressSessions++ }
-        adapter.currentOnCommit = { committed = true }
+        adapter.currentOnProgress = { _, _ -> progressSessions++ }
+        adapter.currentOnCommit = { _ -> committed = true }
 
         // A discrete trigger (e.g. Desktop ESC) reaches the handler as a bare completed callback.
         adapter.handleBackCompleted()
@@ -73,7 +73,7 @@ class NavigationEventFlowAdapterTest {
         // Progress misreported past 1 saturates at the driver cap (see MAX_FINGER_PROGRESS).
         val received = mutableListOf<Float>()
         val adapter = NavigationEventFlowAdapter(this)
-        adapter.currentOnProgress = { events -> events.collect { received += it.progress } }
+        adapter.currentOnProgress = { _, events -> events.collect { received += it.progress } }
 
         adapter.handleBackStarted(NavigationEvent(progress = 0f))
         adapter.handleBackProgressed(NavigationEvent(progress = 1.3f))
@@ -88,8 +88,8 @@ class NavigationEventFlowAdapterTest {
         val received = mutableListOf<Float>()
         var commits = 0
         val adapter = NavigationEventFlowAdapter(this)
-        adapter.currentOnProgress = { events -> events.collect { received += it.progress } }
-        adapter.currentOnCommit = { commits++ }
+        adapter.currentOnProgress = { _, events -> events.collect { received += it.progress } }
+        adapter.currentOnCommit = { _ -> commits++ }
 
         adapter.handleBackStarted(NavigationEvent(progress = 0f))
         adapter.handleBackCompleted()
@@ -103,13 +103,33 @@ class NavigationEventFlowAdapterTest {
     }
 
     @Test
+    fun overlappingTerminalWork_keepsOriginatingSessionIds() = runBlocking {
+        val commits = mutableListOf<Long?>()
+        val cancels = mutableListOf<Long>()
+        val adapter = NavigationEventFlowAdapter(this)
+        adapter.currentOnProgress = { _, events -> events.collect { } }
+        adapter.currentOnCommit = { commits += it }
+        adapter.currentOnCancel = { cancels += it }
+
+        adapter.handleBackStarted(NavigationEvent(progress = 0f))
+        adapter.handleBackCancelled()
+        // Start and complete B before A's asynchronous cancelAndJoin terminal work runs.
+        adapter.handleBackStarted(NavigationEvent(progress = 0f))
+        adapter.handleBackCompleted()
+        coroutineContext.job.children.forEach { it.join() }
+
+        assertContentEquals(listOf(1L), cancels)
+        assertContentEquals(listOf(2L), commits)
+    }
+
+    @Test
     fun rapidCancelledGestures_neverCommitAndEachCancelResolves() = runBlocking {
         var commits = 0
         var cancels = 0
         val adapter = NavigationEventFlowAdapter(this)
-        adapter.currentOnProgress = { events -> events.collect { } }
-        adapter.currentOnCommit = { commits++ }
-        adapter.currentOnCancel = { cancels++ }
+        adapter.currentOnProgress = { _, events -> events.collect { } }
+        adapter.currentOnCommit = { _ -> commits++ }
+        adapter.currentOnCancel = { _ -> cancels++ }
 
         repeat(50) { index ->
             adapter.handleBackStarted(NavigationEvent(progress = 0f))

--- a/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/gesture/NavigationEventFlowAdapterTest.kt
+++ b/miuix-nav/src/desktopTest/kotlin/top/yukonga/miuix/kmp/nav/gesture/NavigationEventFlowAdapterTest.kt
@@ -101,4 +101,24 @@ class NavigationEventFlowAdapterTest {
         assertContentEquals(listOf(0f, 0f, 0.75f), received)
         assertEquals(2, commits)
     }
+
+    @Test
+    fun rapidCancelledGestures_neverCommitAndEachCancelResolves() = runBlocking {
+        var commits = 0
+        var cancels = 0
+        val adapter = NavigationEventFlowAdapter(this)
+        adapter.currentOnProgress = { events -> events.collect { } }
+        adapter.currentOnCommit = { commits++ }
+        adapter.currentOnCancel = { cancels++ }
+
+        repeat(50) { index ->
+            adapter.handleBackStarted(NavigationEvent(progress = 0f))
+            adapter.handleBackProgressed(NavigationEvent(progress = (index % 9 + 1) / 10f))
+            adapter.handleBackCancelled()
+        }
+        coroutineContext.job.children.forEach { it.join() }
+
+        assertEquals(0, commits)
+        assertEquals(50, cancels)
+    }
 }


### PR DESCRIPTION
Prevent the pointer swipe recognizer from committing while system predictive back owns the gesture.

Apply the shared velocity-first release policy when OEMs report completion during strong return motion, and add regression coverage for rapid cancellation and competing gesture sources.