### PR TITLE
library: keep snackbar above the floating toolbar

### DIFF
--- a/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Scaffold.kt
+++ b/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Scaffold.kt
@@ -263,17 +263,6 @@ private fun ScaffoldLayout(
         }
 
         val snackbarHeight = snackbarPlaceable.height
-        val snackbarOffsetFromBottom =
-            if (snackbarHeight != 0) {
-                snackbarHeight +
-                    (
-                        fabOffsetFromBottom
-                            ?: bottomBarPlaceable.height.takeIf { !isBottomBarEmpty }
-                            ?: contentWindowInsets.getBottom(this@SubcomposeLayout)
-                        )
-            } else {
-                0
-            }
 
         // Measure FloatingToolbar
         val floatingToolbarPlaceable =
@@ -282,6 +271,50 @@ private fun ScaffoldLayout(
                 .measure(looseConstraints.offset(-leftInset - rightInset, -bottomInset))
 
         val isFloatingToolbarEmpty = floatingToolbarPlaceable.width == 0 && floatingToolbarPlaceable.height == 0
+
+        // Top edge of the floating toolbar. The snackbar is kept below it when the
+        // toolbar is docked at the bottom so the floating nav bar never covers it
+        // (FAB and bottomBar are already taken into account above).
+        val floatingToolbarTop = if (!isFloatingToolbarEmpty) {
+            val alignment = floatingToolbarPosition.toAlignment()
+            val availableWidth = layoutWidth - leftInset - rightInset
+            val availableHeight = layoutHeight - topBarPlaceable.height - topInset - bottomInset
+            val position = alignment.align(
+                IntSize(floatingToolbarPlaceable.width, floatingToolbarPlaceable.height),
+                IntSize(availableWidth, availableHeight),
+                layoutDirection,
+            )
+            topBarPlaceable.height + topInset + position.y - FloatingToolbarSpacing.roundToPx()
+        } else {
+            0
+        }
+
+        val isFloatingToolbarAtBottom =
+            !isFloatingToolbarEmpty &&
+                (
+                    floatingToolbarPosition == ToolbarPosition.BottomStart ||
+                        floatingToolbarPosition == ToolbarPosition.BottomCenter ||
+                        floatingToolbarPosition == ToolbarPosition.BottomEnd
+                    )
+
+        val snackbarOffsetFromBottom =
+            if (snackbarHeight != 0) {
+                val toolbarOffsetFromBottom =
+                    if (isFloatingToolbarAtBottom) {
+                        (layoutHeight - floatingToolbarTop + FloatingToolbarSpacing.roundToPx())
+                            .coerceAtLeast(0)
+                    } else {
+                        0
+                    }
+                snackbarHeight +
+                    (
+                        fabOffsetFromBottom
+                            ?: bottomBarPlaceable.height.takeIf { !isBottomBarEmpty }
+                            ?: contentWindowInsets.getBottom(this@SubcomposeLayout)
+                        ).coerceAtLeast(toolbarOffsetFromBottom)
+            } else {
+                0
+            }
 
         // Update the backing state for the content padding before subcomposing the body
         val insets = contentWindowInsets.asPaddingValues(this)

--- a/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Scaffold.kt
+++ b/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Scaffold.kt
@@ -272,7 +272,7 @@ private fun ScaffoldLayout(
 
         val isFloatingToolbarEmpty = floatingToolbarPlaceable.width == 0 && floatingToolbarPlaceable.height == 0
 
-        // Top edge of the floating toolbar. The snackbar is kept below it when the
+        // Top edge of the floating toolbar. The snackbar is kept above it when the
         // toolbar is docked at the bottom so the floating nav bar never covers it
         // (FAB and bottomBar are already taken into account above).
         val floatingToolbarTop = if (!isFloatingToolbarEmpty) {

--- a/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Scaffold.kt
+++ b/miuix-ui/src/commonMain/kotlin/top/yukonga/miuix/kmp/basic/Scaffold.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -272,10 +273,10 @@ private fun ScaffoldLayout(
 
         val isFloatingToolbarEmpty = floatingToolbarPlaceable.width == 0 && floatingToolbarPlaceable.height == 0
 
-        // Top edge of the floating toolbar. The snackbar is kept above it when the
+        // Placement of the floating toolbar. The snackbar is kept above it when the
         // toolbar is docked at the bottom so the floating nav bar never covers it
         // (FAB and bottomBar are already taken into account above).
-        val floatingToolbarTop = if (!isFloatingToolbarEmpty) {
+        val floatingToolbarOffset = if (!isFloatingToolbarEmpty) {
             val alignment = floatingToolbarPosition.toAlignment()
             val availableWidth = layoutWidth - leftInset - rightInset
             val availableHeight = layoutHeight - topBarPlaceable.height - topInset - bottomInset
@@ -284,13 +285,16 @@ private fun ScaffoldLayout(
                 IntSize(availableWidth, availableHeight),
                 layoutDirection,
             )
-            topBarPlaceable.height + topInset + position.y - FloatingToolbarSpacing.roundToPx()
+            IntOffset(
+                x = leftInset + position.x,
+                y = topBarPlaceable.height + topInset + position.y - FloatingToolbarSpacing.roundToPx(),
+            )
         } else {
-            0
+            null
         }
 
         val isFloatingToolbarAtBottom =
-            !isFloatingToolbarEmpty &&
+            floatingToolbarOffset != null &&
                 (
                     floatingToolbarPosition == ToolbarPosition.BottomStart ||
                         floatingToolbarPosition == ToolbarPosition.BottomCenter ||
@@ -301,7 +305,7 @@ private fun ScaffoldLayout(
             if (snackbarHeight != 0) {
                 val toolbarOffsetFromBottom =
                     if (isFloatingToolbarAtBottom) {
-                        (layoutHeight - floatingToolbarTop + FloatingToolbarSpacing.roundToPx())
+                        (layoutHeight - (floatingToolbarOffset?.y ?: 0) + FloatingToolbarSpacing.roundToPx())
                             .coerceAtLeast(0)
                     } else {
                         0
@@ -359,25 +363,8 @@ private fun ScaffoldLayout(
             // Place BottomBar
             bottomBarPlaceable.place(0, layoutHeight - bottomBarPlaceable.height)
             // Place FloatingToolbar
-            if (!isFloatingToolbarEmpty) {
-                val floatingToolbarWidth = floatingToolbarPlaceable.width
-                val floatingToolbarHeight = floatingToolbarPlaceable.height
-
-                val alignment = floatingToolbarPosition.toAlignment()
-
-                val availableWidth = layoutWidth - leftInset - rightInset
-                val availableHeight = layoutHeight - topBarPlaceable.height - topInset - bottomInset
-
-                val position = alignment.align(
-                    IntSize(floatingToolbarWidth, floatingToolbarHeight),
-                    IntSize(availableWidth, availableHeight),
-                    layoutDirection,
-                )
-
-                val x = leftInset + position.x
-                val y = topBarPlaceable.height + topInset + position.y - FloatingToolbarSpacing.roundToPx()
-
-                floatingToolbarPlaceable.place(x, y)
+            floatingToolbarOffset?.let { offset ->
+                floatingToolbarPlaceable.place(offset.x, offset.y)
             }
             // Place FAB
             fabPlacement?.let { placement ->


### PR DESCRIPTION
### 问题

`Scaffold` 计算 Snackbar 底部偏移时只考虑了 FAB 和 bottomBar，漏掉了 `floatingToolbar`。使用 `BottomCenter` 悬浮导航栏时，Snackbar 会被导航栏遮挡

### 原因

`ScaffoldLayout` 中 `snackbarOffsetFromBottom` 的取值链为 `fabOffsetFromBottom ?: bottomBarHeight ?: bottomInset`，`floatingToolbar` 未参与计算；且绘制顺序上 toolbar 晚于 snackbar，直接覆盖在其上方

### 修复

将 `floatingToolbar` 的测量提前并计算其顶边位置；当 `floatingToolbarPosition` 为 `BottomStart` / `BottomCenter` / `BottomEnd` 时，Snackbar 底部偏移取 `max(原偏移, 工具栏占用高度 + 间距)`，使其始终显示在悬浮导航栏之上

FAB / bottomBar 的既有行为不变

### 验证

- 在基于本库的 Android 应用（[SimpleXray](https://github.com/ReRokutosei/SimpleXray)）中复现并确认修复（见下方截图）
- `:miuix-ui:spotlessCheck` 通过
***
- Before：snackbar 被导航栏遮挡
  - <img width="5116" height="2376" alt="before" src="https://github.com/user-attachments/assets/86b1ec60-aed3-42eb-89e9-aecf43438028" />
***
- After：snackbar 正常显示
  - <img width="5088" height="2420" alt="after" src="https://github.com/user-attachments/assets/d79451c1-082f-4685-8503-88ad773c088f" />


如果该行为属于项目的有意设计或本修改并非项目所期望，请直接关闭 PR